### PR TITLE
Replace react package README with the most up-to-date version

### DIFF
--- a/packages/sdk-react/README.md
+++ b/packages/sdk-react/README.md
@@ -10,19 +10,15 @@ An SDK for using FusionAuth in React applications.
 
   - [Configuring Provider](#configuring-provider)
 
-  - [Server Code Requirements](#server-code-requirements)
-
 - [Usage](#usage)
 
-  - [Pre-built buttons](#pre-built-buttons)
+	- [Pre-built buttons](#pre-built-buttons)
 
-  - [Programmatic usage](#programmatic-usage)
+	-   [Programmatic usage](#programmatic-usage)
 
-  - [Protecting content](#protecting-content)
+	-   [Protecting content](#protecting-content)
 
-  - [Known issues](#known-issues)
-
-- [Example App](#example-app)
+	-   [Known issues](#known-issues)
 
 - [Quickstart](#quickstart)
 
@@ -52,23 +48,22 @@ then log in. After that, they are sent back to your React application.
 Once authentication succeeds, the following secure, HTTP-only cookies
 will be set:
 
-- `app.at` - an OAuth [Access
-  Token](https://fusionauth.io/docs/v1/tech/oauth/tokens#access-token)
+-   `app.at` - an OAuth [Access
+    Token](https://fusionauth.io/docs/v1/tech/oauth/tokens#access-token)
 
-- `app.rt` - a [Refresh
-  Token](https://fusionauth.io/docs/v1/tech/oauth/tokens#refresh-token)
-  used to obtain a new `app.at`. This cookie will only be set if
-  refresh tokens are enabled on your FusionAuth instance.
+-   `app.rt` - a [Refresh
+    Token](https://fusionauth.io/docs/v1/tech/oauth/tokens#refresh-token)
+    used to obtain a new `app.at`. This cookie will only be set if
+    refresh tokens are enabled on your FusionAuth instance.
 
 The access token can be presented to APIs to authorize the request and
 the refresh token can be used to get a new access token.
 
 There are 2 ways to interact with this SDK:
+1. By hosting your own server that performs the OAuth token exchange and meets the [server code requirements for FusionAuth Web SDKs](https://github.com/FusionAuth/fusionauth-javascript-sdk-express#server-code-requirements).
+2. By using the server hosted on your FusionAuth instance, i.e., not writing your own server code.
 
-1. Host your own server that performs the OAuth token exchange. See [Server Code
-   Requirements](#server-code-requirements) for more details. - Example app with server code: [fusionauth-example-react-sdk](https://github.com/FusionAuth/fusionauth-example-react-sdk)
-2. Use the endpoints hosted by your FusionAuth instance to perform the OAuth token exchange for you.
-   - Example app without server code: [fusionauth-quickstart-javascript-react-web](https://github.com/FusionAuth/fusionauth-quickstart-javascript-react-web)
+If you are hosting your own server, see [server code requirements](https://github.com/FusionAuth/fusionauth-javascript-sdk-express#server-code-requirements).
 
 You can use this library against any version of FusionAuth or any OIDC
 compliant identity server.
@@ -112,104 +107,6 @@ const root = createRoot(container!);
         </FusionAuthProvider>
     );
 ```
-
-<!-- this is pulled into docs and our link checker complains if we don't have the id tag here -->
-<h2 id="server-code-requirements">Server Code Requirements</h2>
-
-If you set up your own server to perform the OAuth token exchange, it must have the following endpoints:
-
-#### `GET /app/login`
-
-This endpoint must:
-
-1.  Generate PKCE code.
-    a. The code verifier should be saved in a secure HTTP-only cookie.
-    b. The code challenge is passed along
-2.  Encode and save `redirect_url` from react app to `state`.
-3.  Redirect browser to `/oauth2/authorize` with a `redirect_uri` to `/app/token-exchange`
-
-[Example
-implementation](https://github.com/FusionAuth/fusionauth-example-react-sdk/blob/main/server/routes/login.js)
-
-#### `GET /app/callback`
-
-This endpoint must:
-
-1.  Call
-    [/oauth2/token](https://fusionauth.io/docs/v1/tech/oauth/endpoints#complete-the-authorization-code-grant-request)
-    to complete the Authorization Code Grant request. The `code` comes from the request query parameter and
-    `code_verifier` should be available in the secure HTTP-only cookie, while
-    the rest of the parameters should be set/configured on the server
-    side.
-
-2.  Once the token exchange succeeds, read the `app.at` from the
-    response body and set it as a secure, HTTP-only cookie with the same
-    name.
-
-3.  If you wish to support refresh tokens, repeat step 2 for the
-    `app.rt` cookie.
-
-4.  Save the expiration time in a readable `app.at_exp` cookie. And save the `app.idt` id token in a readable cookie.
-
-5.  Redirect browser back to encoded url saved in `state`.
-
-6.  Call
-    [/oauth2/userinfo](https://fusionauth.io/docs/v1/tech/oauth/endpoints#userinfo)
-    to retrieve the user info object and respond back to the client with
-    this object.
-
-[Example
-implementation](https://github.com/FusionAuth/fusionauth-example-react-sdk/blob/main/server/routes/callback.js)
-
-#### `GET /app/register`
-
-This endpoint is similar to `/login`. It must:
-
-1.  Generate PKCE code.
-    a. The code verifier should be saved in a secure HTTP-only cookie.
-    b. The code challenge is passed along
-2.  Encode and save `redirect_url` from react app to `state`.
-3.  Redirect browser to `/oauth2/register` with a `redirect_uri` to `/app/callback`
-
-[Example
-implementation](https://github.com/FusionAuth/fusionauth-example-react-sdk/blob/main/server/routes/register.js)
-
-#### `GET /app/me`
-
-This endpoint must:
-
-1.  Use `app.at` from cookie and use as the Bearer token to call `/oauth2/userinfo`
-2.  Return json data
-
-[Example
-implementation](https://github.com/FusionAuth/fusionauth-example-react-sdk/blob/main/server/routes/me.js)
-
-#### `GET /app/logout`
-
-This endpoint must:
-
-1.  Clear the `app.at` and `app.rt` secure, HTTP-only
-    cookies.
-2.  Clear the `app.at_exp` and `app.idt` secure cookies.
-3.  Redirect to `/oauth2/logout`
-
-[Example
-implementation](https://github.com/FusionAuth/fusionauth-example-react-sdk/blob/main/server/routes/logout.js)
-
-#### `POST /app/token-refresh` (optional)
-
-This endpoint is necessary if you wish to use refresh tokens. This
-endpoint must:
-
-1.  Call
-    [/oauth2/token](https://fusionauth.io/docs/v1/tech/oauth/endpoints#refresh-token-grant-request)
-    to get a new `app.at` and `app.rt`.
-
-2.  Update the `app.at`, `app.at_exp`, `app.idt`, and `app.rt` cookies from the
-    response.
-
-[Example
-implementation](https://github.com/FusionAuth/fusionauth-example-react-sdk/blob/main/server/routes/token-refresh.js)
 
 ## Usage
 
@@ -373,13 +270,6 @@ disabled.
 If you remove the `React.StrictMode` tags in `index.tsx` of the example
 app, the call is only made once.
 
-## Example App
-
-See the [FusionAuth React SDK
-Example](https://github.com/FusionAuth/fusionauth-example-react-sdk) for
-functional example of a React client that utilizes the SDK as well as an
-Express server that performs the token exchange.
-
 ## Quickstart
 
 See the [FusionAuth React Quickstart](https://fusionauth.io/docs/quickstarts/quickstart-javascript-react-web) for a full tutorial on using FusionAuth and React.
@@ -399,8 +289,8 @@ Use backticks for code in this readme. This readme is included on the FusionAuth
 
 There are several linting packages run when you push to a branch. One is `prettier`. If this fails, you can fix the files from the command line:
 
-- npm run install
-- npm run prettier -- -w /path/to/file
+* npm run install
+* npm run prettier -- -w /path/to/file
 
 Doing this will overwrite your file, but fix prettier's objections.
 


### PR DESCRIPTION
Replacing the react package README with the version that has no server requirements section.
The version that was merged into the non-monorepo here: https://github.com/FusionAuth/fusionauth-react-sdk/pull/97, which was a task related to [this fusionauth-issues ticket](https://github.com/FusionAuth/fusionauth-issues/issues/2682)