### PR TITLE
:memo: Adding upgrade policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,11 @@ For now, please view the existing repos:
 * [FusionAuth React SDK](https://github.com/FusionAuth/fusionauth-react-sdk)
 * [FusionAuth Angular SDK](https://github.com/FusionAuth/fusionauth-angular-sdk)
 * [FusionAuth Vue SDK](https://github.com/FusionAuth/fusionauth-vue-sdk)
+
+## Upgrade Policy
+
+This library may periodically receive updates with bug fixes, security patches, tests, code samples, or documentation changes.
+
+These releases may also update dependencies, language engines, and operating systems, as we\'ll follow the deprecation and sunsetting policies of the underlying technologies that the libraries use.
+
+This means that after a dependency (e.g. language, framework, or operating system) is deprecated by its maintainer, this library will also be deprecated by us, and may eventually be updated to use a newer version.


### PR DESCRIPTION
Adding the "Upgrade Policy" section as [described here](https://github.com/FusionAuth/fusionauth-site/pull/2916).