### PR TITLE
Add GitHub workflow to publish Vue SDK

### DIFF
--- a/.github/workflows/publish-sdk-vue.yml
+++ b/.github/workflows/publish-sdk-vue.yml
@@ -1,0 +1,40 @@
+name: Publish @fusionauth/vue-sdk
+
+on: workflow_dispatch
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+      - name: Vue SDK - Install packages
+        run: yarn install --frozen-lockfile
+      - name: Vue SDK - Test
+        run: yarn test:sdk-vue
+
+  publish-sdk-vue:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org/
+      - run: yarn install --frozen-lockfile
+      - name: Vue SDK - Build
+        run: yarn build:sdk-vue
+      - name: Vue SDK - Publish
+        working-directory: ./packages/sdk-vue/dist
+        run: npm publish --dry-run
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
#8 Adding a GitHub Workflow to publish [`@fusionauth/vue-sdk`](https://fusionauth.io/docs/sdks/vue-sdk) via GitHub Actions.

We will need to address #21 before we can start using these workflows -- requires settings permissions for this repo.