### PR TITLE
Upgrade actions versions, and swap `npm` for `yarn`

### DIFF
--- a/.github/workflows/publish-sdk-react.yml
+++ b/.github/workflows/publish-sdk-react.yml
@@ -9,30 +9,30 @@ jobs:
       matrix:
         node-version: [18.x, 20.x]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
       - name: React SDK - Install packages
         run: yarn install --frozen-lockfile
       - name: React SDK - Test
-        run: npm run test:sdk-react
+        run: yarn test:sdk-react
 
   publish-sdk-react:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js 20
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org/
       - run: yarn install --frozen-lockfile
       - name: React SDK - Build
-        run: npm run build:sdk-react
+        run: yarn build:sdk-react
       - name: React SDK - Publish
         working-directory: ./packages/sdk-react/dist
         run: npm publish --dry-run


### PR DESCRIPTION
An extension of issue #7.

**Changes**
- Upgrading `actions/setup-node@v3` to `v4`. Based on [annotations](https://github.com/FusionAuth/fusionauth-javascript-sdk/actions/runs/8346070743) from our test run of this workflow. [actions/setup-node changelog](https://github.com/actions/setup-node/releases/tag/v4.0.0) corroborates.
- Swapping `npm` for `yarn` to run commands. (Leaving `npm` publish, since we are comfortable with that)