### PR TITLE
34 react automatic refresh tokens

### DIFF
--- a/packages/core/src/CookieHelpers/CookieHelpers.ts
+++ b/packages/core/src/CookieHelpers/CookieHelpers.ts
@@ -1,10 +1,15 @@
 export class CookieHelpers {
-  /** Parses document.cookie for the 'app.at_exp' value in milliseconds. */
-  static getAuthTokenExpirationTime(): number | null {
+  /**
+   * Parses document.cookie for the auth token expiration cookie value.
+   * @returns {(number | null)} The moment of expiration in milliseconds since epoch.
+   */
+  static getAuthTokenExpirationTime(
+    cookieName: string = 'app.at_exp',
+  ): number | null {
     const expCookie = document.cookie
       .split('; ')
       .map(c => c.split('='))
-      .find(([name]) => name === 'app.at_exp');
+      .find(([name]) => name === cookieName);
     const cookieValue = expCookie?.[1];
     return cookieValue ? parseInt(cookieValue) * 1000 : null;
   }

--- a/packages/core/src/TokenRefresher/TokenRefresher.test.ts
+++ b/packages/core/src/TokenRefresher/TokenRefresher.test.ts
@@ -29,17 +29,17 @@ describe('UrlHelpers.generateUrl', () => {
   });
 
   it('Initialize automatic refresh', async () => {
-    const url = new URL('http://token-refresh-class.com/refresh-token');
-    const tokenRefresher = new TokenRefresher(url);
+    const tokenRefresher = new TokenRefresher(
+      new URL('http://token-refresh-class.com/refresh-token'),
+    );
 
     tokenRefresher.refreshToken = vi.fn();
 
     const expirationTime = new Date();
-    expirationTime.setHours(expirationTime.getHours() + 1); // 1 hour in the future
+    expirationTime.setHours(expirationTime.getHours() + 1);
+    document.cookie = `app.at_exp=${expirationTime.getTime() / 1000}`; // token will expire 1 hour in the future
 
-    document.cookie = `app.at_exp=${expirationTime.getTime() / 1000}`; // set cookie as epoch time
-
-    const timeout = tokenRefresher.initAutoRefresh(30); // refresh 30 seconds before expiration
+    const timeout = tokenRefresher.initAutoRefresh(30); // set autorefresh for 30 seconds before expiration
 
     vi.advanceTimersByTime(59 * 60 * 1000); // advance time 59 minutes
     expect(tokenRefresher.refreshToken).not.toHaveBeenCalled();

--- a/packages/core/src/TokenRefresher/TokenRefresher.test.ts
+++ b/packages/core/src/TokenRefresher/TokenRefresher.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { TokenRefresher } from 'src/TokenRefresher';
+
+describe('UrlHelpers.generateUrl', () => {
+  beforeEach(() => {
+    vi.spyOn(window, 'fetch').mockResolvedValue({ status: 200 } as Response);
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('Should request the given URL', async () => {
+    const url = new URL('http://token-refresh-class.com/refresh-token');
+    const tokenRefresher = new TokenRefresher(url);
+
+    await tokenRefresher.refreshToken();
+
+    expect(fetch).toHaveBeenCalledWith(url.href, {
+      method: 'POST',
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'text/plain',
+      },
+    });
+  });
+
+  it('Initialize automatic refresh', async () => {
+    const url = new URL('http://token-refresh-class.com/refresh-token');
+    const tokenRefresher = new TokenRefresher(url);
+
+    tokenRefresher.refreshToken = vi.fn();
+
+    const expirationTime = new Date();
+    expirationTime.setHours(expirationTime.getHours() + 1); // 1 hour in the future
+
+    document.cookie = `app.at_exp=${expirationTime.getTime() / 1000}`; // set cookie as epoch time
+
+    const timeout = tokenRefresher.initAutoRefresh(30); // refresh 30 seconds before expiration
+
+    vi.advanceTimersByTime(59 * 60 * 1000); // advance time 59 minutes
+    expect(tokenRefresher.refreshToken).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(29 * 1000); // advance time 29 seconds
+    expect(tokenRefresher.refreshToken).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1000); // advance time 1 second
+    expect(tokenRefresher.refreshToken).toHaveBeenCalledTimes(1);
+
+    clearTimeout(timeout);
+  });
+});

--- a/packages/core/src/TokenRefresher/TokenRefresher.ts
+++ b/packages/core/src/TokenRefresher/TokenRefresher.ts
@@ -1,0 +1,61 @@
+import { CookieHelpers } from 'src/CookieHelpers';
+
+class TokenRefresher {
+  url: URL;
+
+  constructor(url: URL) {
+    this.url = url;
+  }
+
+  /**
+   * Calls the configured 'refresh' endpoint to attempt to refresh the access token cookie.
+   */
+  async refreshToken(): Promise<void> {
+    const resp = await fetch(this.url.href, {
+      method: 'POST',
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'text/plain',
+      },
+    });
+    if (!(resp.status >= 200 && resp.status < 300)) {
+      throw new Error('error refreshing access token in fusionauth');
+    }
+  }
+
+  /**
+   * Checks for the 'app.at_exp' cookie and if present sets a timer to refresh the access token.
+   * Will attempt to refresh the configured seconds before the access token expires (default is ten seconds).
+   */
+  initAutoRefresh(
+    refreshBeforeSeconds: number = 10,
+    authTokenExpirationCookieName?: string,
+  ) {
+    const tokenExpirationMoment = CookieHelpers.getAuthTokenExpirationTime(
+      authTokenExpirationCookieName,
+    );
+    const millisecondsBeforeRefresh = refreshBeforeSeconds * 1000;
+
+    if (!tokenExpirationMoment) {
+      return;
+    }
+
+    const now = new Date().getTime();
+    const refreshTime = tokenExpirationMoment - millisecondsBeforeRefresh;
+
+    const timeTillRefresh = Math.max(refreshTime - now, 0);
+
+    const timeout = setTimeout(async () => {
+      try {
+        await this.refreshToken();
+        this.initAutoRefresh(refreshBeforeSeconds);
+      } catch (e) {
+        console.error(e);
+      }
+    }, timeTillRefresh);
+
+    return timeout;
+  }
+}
+
+export { TokenRefresher };

--- a/packages/core/src/TokenRefresher/TokenRefresher.ts
+++ b/packages/core/src/TokenRefresher/TokenRefresher.ts
@@ -25,20 +25,21 @@ class TokenRefresher {
 
   /**
    * Checks for the 'app.at_exp' cookie and if present sets a timer to refresh the access token.
-   * Will attempt to refresh the configured seconds before the access token expires (default is ten seconds).
+   * Will attempt to refresh at the specified time before the access token expires (default is 10 seconds).
    */
   initAutoRefresh(
-    refreshBeforeSeconds: number = 10,
+    secondsBeforeRefresh: number = 10,
     authTokenExpirationCookieName?: string,
   ) {
     const tokenExpirationMoment = CookieHelpers.getAuthTokenExpirationTime(
       authTokenExpirationCookieName,
     );
-    const millisecondsBeforeRefresh = refreshBeforeSeconds * 1000;
 
     if (!tokenExpirationMoment) {
       return;
     }
+
+    const millisecondsBeforeRefresh = secondsBeforeRefresh * 1000;
 
     const now = new Date().getTime();
     const refreshTime = tokenExpirationMoment - millisecondsBeforeRefresh;
@@ -48,7 +49,7 @@ class TokenRefresher {
     const timeout = setTimeout(async () => {
       try {
         await this.refreshToken();
-        this.initAutoRefresh(refreshBeforeSeconds);
+        this.initAutoRefresh(secondsBeforeRefresh);
       } catch (e) {
         console.error(e);
       }

--- a/packages/core/src/TokenRefresher/index.ts
+++ b/packages/core/src/TokenRefresher/index.ts
@@ -1,0 +1,1 @@
+export * from './TokenRefresher';

--- a/packages/core/src/UrlHelpers/UrlHelpers.test.ts
+++ b/packages/core/src/UrlHelpers/UrlHelpers.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+
+import { UrlGenerationConfig, UrlHelpers } from 'src/UrlHelpers';
+
+describe('UrlHelpers.generateUrl', () => {
+  it('Should generate a url correctly based on configuration', () => {
+    const config: UrlGenerationConfig = {
+      serverUrlString: 'http://my-server',
+      path: '/my-path',
+      clientId: 'abc123',
+      params: {
+        redirectUri: 'http://my-client',
+        state: 'my-state',
+      },
+    };
+    const url = UrlHelpers.generateUrl(config);
+    expect(url.href).toBe(
+      'http://my-server/my-path/abc123?redirectUri=http%3A%2F%2Fmy-client&state=my-state',
+    );
+  });
+});

--- a/packages/core/src/UrlHelpers/UrlHelpers.ts
+++ b/packages/core/src/UrlHelpers/UrlHelpers.ts
@@ -1,0 +1,41 @@
+export type UrlGenerationConfig = {
+  serverUrlString: string;
+  path: string;
+  clientId: string;
+  params?: UrlGenerationParams;
+};
+
+type UrlGenerationParams = {
+  redirectUri: string;
+  state?: string;
+  scope?: string;
+};
+
+export class UrlHelpers {
+  /** Generates a URL configured with clientId and search params. */
+  static generateUrl(config: UrlGenerationConfig): URL {
+    const url = new URL(config.serverUrlString);
+    url.pathname = `${config.path}/${config.clientId}`;
+
+    if (config.params) {
+      const urlSearchParams = _generateURLSearchParams(config.params);
+      url.search = urlSearchParams.toString();
+    }
+
+    return url;
+  }
+}
+
+function _generateURLSearchParams(
+  params: Record<string, string>,
+): URLSearchParams {
+  const urlSearchParams = new URLSearchParams();
+
+  Object.entries(params).forEach(([key, value]) => {
+    if (value) {
+      urlSearchParams.append(key, value);
+    }
+  });
+
+  return urlSearchParams;
+}

--- a/packages/core/src/UrlHelpers/UrlHelpers.ts
+++ b/packages/core/src/UrlHelpers/UrlHelpers.ts
@@ -27,7 +27,7 @@ export class UrlHelpers {
 }
 
 function _generateURLSearchParams(
-  params: Record<string, string>,
+  params: UrlGenerationParams,
 ): URLSearchParams {
   const urlSearchParams = new URLSearchParams();
 

--- a/packages/core/src/UrlHelpers/index.ts
+++ b/packages/core/src/UrlHelpers/index.ts
@@ -1,0 +1,1 @@
+export * from './UrlHelpers';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,1 +1,3 @@
 export * from './CookieHelpers';
+export * from './UrlHelpers';
+export * from './TokenRefresher';

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -18,7 +18,11 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+
+    "paths": {
+      "src/*": ["./src/*"]
+    }
   },
   "include": ["src"]
 }

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -21,4 +21,9 @@ export default defineConfig({
   server: {
     port: 3001,
   },
+  resolve: {
+    alias: {
+      src: '/src',
+    },
+  },
 });

--- a/packages/sdk-react/src/components/providers/FusionAuthProvider.test.tsx
+++ b/packages/sdk-react/src/components/providers/FusionAuthProvider.test.tsx
@@ -1,0 +1,272 @@
+import React, { PropsWithChildren } from 'react';
+import { waitFor, renderHook } from '@testing-library/react';
+import { describe, afterEach, test, expect, beforeEach, vi } from 'vitest';
+
+import {
+  FusionAuthProvider,
+  useFusionAuth,
+} from '#/components/providers/FusionAuthProvider';
+import { mockCrypto } from '#/testing-tools/mocks/mockCrypto';
+import { mockFetchJson } from '#/testing-tools/mocks/mockFetchJson';
+import { TEST_CONFIG } from '#testing-tools/mocks/testConfig';
+
+let location: Location;
+
+describe('FusionAuthProvider', () => {
+  beforeEach(() => {
+    location = window.location;
+    vi.spyOn(window, 'location', 'get').mockRestore();
+
+    mockCrypto();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('Login function will navigate to the correct url', () => {
+    const mockedLocation = {
+      ...location,
+      assign: vi.fn(),
+    };
+    vi.spyOn(window, 'location', 'get').mockReturnValue(mockedLocation);
+
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <FusionAuthProvider {...TEST_CONFIG}>{children}</FusionAuthProvider>
+    );
+    const { result } = renderHook(() => useFusionAuth(), {
+      wrapper,
+    });
+
+    result.current.login('state');
+
+    const expectedUrl =
+      'http://localhost:9000/app/login?client_id=85a03867-dccf-4882-adde-1a79aeec50df&scope=openid+offline_access&redirect_uri=http%3A%2F%2Flocalhost&state=00000000000000000000000000000000000000000000000000000000%3Astate';
+    expect(mockedLocation.assign).toHaveBeenCalledWith(expectedUrl);
+  });
+
+  test('User set to the value stored in the cookie', () => {
+    const trent = { name: 'trent anderson' };
+    Object.defineProperty(document, 'cookie', {
+      writable: true,
+      value: `user=${JSON.stringify(trent)}`,
+    });
+
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <FusionAuthProvider {...TEST_CONFIG}>{children}</FusionAuthProvider>
+    );
+    const { result } = renderHook(() => useFusionAuth(), {
+      wrapper,
+    });
+
+    expect(result.current.user).toEqual(trent);
+    expect(result.current.isAuthenticated).toBe(true);
+  });
+
+  test('Will fetch the user from the server when the id token cookie is set', async () => {
+    Object.defineProperty(document, 'cookie', {
+      writable: true,
+      value: `app.idt=12345`,
+    });
+
+    const user = { name: 'Mr. Userton' };
+    const mockResponse = {
+      ok: true,
+      json: () => Promise.resolve(user),
+    } as Response;
+    vi.spyOn(global, 'fetch').mockResolvedValue(mockResponse);
+
+    const serverUrl = 'http://my-server.com';
+    const mePath = '/my-me-path';
+
+    const { result } = renderHook(() => useFusionAuth(), {
+      wrapper: ({ children }) => (
+        <FusionAuthProvider
+          {...TEST_CONFIG}
+          serverUrl={serverUrl}
+          mePath={mePath}
+        >
+          {children}
+        </FusionAuthProvider>
+      ),
+    });
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.user).toEqual({});
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(fetch).toHaveBeenCalledWith(serverUrl + mePath, {
+      credentials: 'include',
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.user).toEqual(user);
+      expect(result.current.isAuthenticated).toBe(true);
+      expect(fetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  test('User to empty when user cookie is not json parsable', () => {
+    const mockedLocation = {
+      ...location,
+      assign: vi.fn(),
+    };
+    vi.spyOn(window, 'location', 'get').mockReturnValue(mockedLocation);
+
+    Object.defineProperty(document, 'cookie', {
+      writable: true,
+      value: 'user=undefined',
+    });
+
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <FusionAuthProvider {...TEST_CONFIG}>{children}</FusionAuthProvider>
+    );
+    const { result } = renderHook(() => useFusionAuth(), {
+      wrapper,
+    });
+
+    expect(result.current.user).toEqual({});
+    expect(result.current.isAuthenticated).toEqual(false);
+  });
+
+  test('Logout function will navigate to the correct url', () => {
+    mockFetchJson({});
+    const mockedLocation = {
+      ...location,
+      assign: vi.fn(),
+    };
+    vi.spyOn(window, 'location', 'get').mockReturnValue(mockedLocation);
+
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <FusionAuthProvider {...TEST_CONFIG}>{children}</FusionAuthProvider>
+    );
+    const { result } = renderHook(() => useFusionAuth(), {
+      wrapper,
+    });
+
+    result.current.logout();
+
+    const expectedUrl =
+      'http://localhost:9000/app/logout?client_id=85a03867-dccf-4882-adde-1a79aeec50df&post_logout_redirect_uri=http%3A%2F%2Flocalhost';
+
+    expect(mockedLocation.assign).toHaveBeenCalledWith(expectedUrl);
+  });
+
+  test('Register function will navigate to the correct url', () => {
+    const mockedLocation = {
+      ...location,
+      assign: vi.fn(),
+    };
+    vi.spyOn(window, 'location', 'get').mockReturnValue(mockedLocation);
+
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <FusionAuthProvider {...TEST_CONFIG}>{children}</FusionAuthProvider>
+    );
+    const { result } = renderHook(() => useFusionAuth(), {
+      wrapper,
+    });
+
+    result.current.register('state');
+
+    const expectedUrl =
+      'http://localhost:9000/app/register?client_id=85a03867-dccf-4882-adde-1a79aeec50df&redirect_uri=http%3A%2F%2Flocalhost&scope=openid+offline_access&state=00000000000000000000000000000000000000000000000000000000%3Astate';
+    expect(mockedLocation.assign).toHaveBeenCalledWith(expectedUrl);
+  });
+
+  test('Will invoke the onRedirectFail callback only once', async () => {
+    Object.defineProperty(document, 'cookie', {
+      writable: true,
+      // lastState should ensure redirect handlers are called
+      value: 'lastState=abc123; app.idt=abc123;',
+    });
+
+    const redirectFailHandler = vi.fn();
+
+    const errorResponse = {
+      ok: false,
+      json: () => Promise.resolve({ message: 'something went wrong' }),
+    } as Response;
+    vi.spyOn(global, 'fetch').mockResolvedValue(errorResponse);
+
+    renderHook(() => useFusionAuth(), {
+      wrapper: ({ children }) => (
+        <FusionAuthProvider
+          {...TEST_CONFIG}
+          onRedirectFail={redirectFailHandler}
+        >
+          {children}
+        </FusionAuthProvider>
+      ),
+    });
+
+    await waitFor(() => {
+      expect(redirectFailHandler).toHaveBeenCalledTimes(1);
+      expect(redirectFailHandler).toHaveBeenCalled();
+      expect(document.cookie).toContain('lastState=;'); // lastState cookie was removed
+    });
+  });
+
+  test('Will invoke the onRedirectSuccess callback only once', async () => {
+    const stateValue = 'some-value';
+    Object.defineProperty(document, 'cookie', {
+      writable: true,
+      // lastState should ensure redirect handlers are called
+      value: `lastState=12345:${stateValue}; app.idt=abc123;`,
+    });
+
+    const redirectSuccessHandler = vi.fn();
+    const response = {
+      ok: true,
+      json: () => Promise.resolve({ name: 'Johnny' }),
+    } as Response;
+    vi.spyOn(global, 'fetch').mockResolvedValue(response);
+
+    renderHook(() => useFusionAuth(), {
+      wrapper: ({ children }) => (
+        <FusionAuthProvider
+          {...TEST_CONFIG}
+          onRedirectSuccess={redirectSuccessHandler}
+        >
+          {children}
+        </FusionAuthProvider>
+      ),
+    });
+
+    await waitFor(() => {
+      expect(redirectSuccessHandler).toHaveBeenCalledTimes(1);
+      expect(redirectSuccessHandler).toHaveBeenCalledWith(stateValue);
+      expect(document.cookie).toContain('lastState=;'); // lastState cookie was removed
+    });
+  });
+
+  test('Will not invoke onRedirectSuccess when lastState cookie is not set', async () => {
+    Object.defineProperty(document, 'cookie', {
+      writable: true,
+      value: `app.idt=abc123;`,
+    });
+
+    const redirectSuccessHandler = vi.fn();
+    const alan = { name: 'Alan Turing' };
+    const response = {
+      ok: true,
+      json: () => Promise.resolve(alan),
+    } as Response;
+    vi.spyOn(global, 'fetch').mockResolvedValue(response);
+
+    const { result } = renderHook(() => useFusionAuth(), {
+      wrapper: ({ children }) => (
+        <FusionAuthProvider
+          {...TEST_CONFIG}
+          onRedirectSuccess={redirectSuccessHandler}
+        >
+          {children}
+        </FusionAuthProvider>
+      ),
+    });
+
+    await waitFor(() => {
+      expect(result.current.user.name).toBe('Alan Turing'); // user was fetched successfully without invoking redirect handler
+      expect(redirectSuccessHandler).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## What is this PR and why do we need it?
#34 -- feature request for React SDK. SDK should automatically call the refresh endpoint just before the token expires (default is 30sec before expiration).

Adding this feature via the SDK Core but this branch only integrates it into React. Subsequent PRs will replace the Angular and Vue code with SDK Core code.

**More Context**
The FusionAuth hosted endpoints are configured to expire tokens 1hr after they are issued. So you should expect to see a network request to refresh after 59m 30s after logging in. If you are testing against the quickstart app, you may configure the provider with a short expiry window. That would be something like `3590` (59m 50s _before_ expiration). With that, you should expect to see a request to refresh the token every 10 seconds.

#### Pre-Merge Checklist (if applicable)
- [x] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.
