### PR TITLE
[Angular] implement core/TokenRefresher and core/UrlHelper

### DIFF
--- a/packages/core/src/TokenRefresher/TokenRefresher.ts
+++ b/packages/core/src/TokenRefresher/TokenRefresher.ts
@@ -1,5 +1,6 @@
 import { CookieHelpers } from 'src/CookieHelpers';
 
+/** A class responsible for handling access token refresh. */
 class TokenRefresher {
   url: URL;
 

--- a/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.spec.ts
+++ b/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.spec.ts
@@ -7,6 +7,7 @@ describe('FusionAuthService', () => {
   const config: FusionAuthConfig = {
     clientId: 'e9fdb985-9173-4e01-9d73-ac2d60d1dc8e',
     loginPath: '/app/login',
+    redirectUri: 'http://my-app.com',
     serverUrl: 'http://localhost:9011',
   };
 

--- a/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts
+++ b/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts
@@ -3,7 +3,10 @@ export interface FusionAuthConfig {
   clientId: string;
   redirectUri?: string;
 
+  /** The number of seconds before the access token expiry when the auto refresh functionality kicks in if enabled. Default is 10. */
   autoRefreshSecondsBeforeExpiry?: number;
+  /** Enables automatic token refreshing. Defaults to false. */
+  shouldAutoRefresh?: boolean;
   loginPath?: string;
   logoutPath?: string;
   registerPath?: string;


### PR DESCRIPTION
## What is this PR and why do we need it?
This reimplements the token refresh functionality functionality for Angular using code from the SDK Core package.
Also reimplements the url building functionality, which is used in the token refresh flow.

This is part of our longer running task to extract non-framework-specific logic from the SDK packages and re-implement it via the core package.

There should be no observable changes or regressions.

#### Pre-Merge Checklist (if applicable)
- [x] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.
