### PR TITLE
[React] Adds option to not auto refresh

### DIFF
--- a/packages/sdk-react/src/components/providers/FusionAuthProvider.tsx
+++ b/packages/sdk-react/src/components/providers/FusionAuthProvider.tsx
@@ -22,6 +22,7 @@ export interface IFusionAuthContext {
   isLoading: boolean;
   isAuthenticated: boolean;
   refreshToken: () => Promise<void>;
+  initAutoTokenRefresh: () => void;
 }
 
 export const FusionAuthContext = React.createContext<IFusionAuthContext>({
@@ -32,6 +33,7 @@ export const FusionAuthContext = React.createContext<IFusionAuthContext>({
   isLoading: false,
   isAuthenticated: false,
   refreshToken: () => Promise.resolve(),
+  initAutoTokenRefresh: () => {},
 });
 
 export type RedirectSuccess = (state: string) => void;
@@ -44,7 +46,9 @@ export interface FusionAuthConfig extends PropsWithChildren {
   onRedirectSuccess?: RedirectSuccess;
   onRedirectFail?: RedirectFail;
   scope?: string;
-  /** The amount of seconds before the auth token is automatically refreshed. Default is 30. */
+  /** Enables automatic token refreshing. Defaults to false. */
+  shouldAutoRefreshAccessToken?: boolean;
+  /** The number of seconds before the access token expiry when the auto refresh functionality kicks in if enabled. Default is 30. */
   accessTokenExpireWindow?: number;
   accessTokenExpireCookieName?: string;
   loginPath?: string;
@@ -150,8 +154,10 @@ export const FusionAuthProvider: React.FC<FusionAuthConfig> = props => {
   ]);
 
   useEffect(() => {
-    initAutoTokenRefresh();
-  }, [initAutoTokenRefresh]);
+    if (props.shouldAutoRefreshAccessToken) {
+      initAutoTokenRefresh();
+    }
+  }, [initAutoTokenRefresh, props.shouldAutoRefreshAccessToken]);
 
   const refreshToken = useCallback(
     async () => await tokenRefresher.refreshToken(),
@@ -235,8 +241,18 @@ export const FusionAuthProvider: React.FC<FusionAuthConfig> = props => {
       isLoading,
       user,
       refreshToken,
+      initAutoTokenRefresh,
     }),
-    [login, logout, register, isAuthenticated, isLoading, refreshToken, user],
+    [
+      login,
+      logout,
+      register,
+      isAuthenticated,
+      isLoading,
+      refreshToken,
+      user,
+      initAutoTokenRefresh,
+    ],
   );
 
   return (

--- a/packages/sdk-react/src/components/ui/RequireAuth/RequireAuth.test.tsx
+++ b/packages/sdk-react/src/components/ui/RequireAuth/RequireAuth.test.tsx
@@ -163,6 +163,7 @@ const renderWithContext = ({
     isLoading: false,
     isAuthenticated: true,
     refreshToken: () => Promise.resolve(),
+    initAutoTokenRefresh: () => {},
     ...context,
   };
 

--- a/packages/sdk-react/src/testing-tools/mocks/createContextMock.ts
+++ b/packages/sdk-react/src/testing-tools/mocks/createContextMock.ts
@@ -10,5 +10,6 @@ export const createContextMock = (
   isAuthenticated: context.isAuthenticated ?? false,
   user: context.user ?? {},
   refreshToken: context.refreshToken ?? vi.fn(),
+  initAutoTokenRefresh: context.initAutoTokenRefresh ?? vi.fn(),
   isLoading: context.isLoading ?? false,
 });


### PR DESCRIPTION
## What is this PR and why do we need it?
For the React SDK, this adds the `shouldAutoRefreshAccessToken` option. Users of the SDK must explicitly set this option to turn on the auto refresh feature.

This is parity with pull #50. We need this option, so that apps currently using the SDK don't need to change their implementation. In other words, it's an additive change for Angular and Vue, so we are bringing the React SDK API to parity.

#### Pre-Merge Checklist (if applicable)
- [x] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.
