### PR TITLE
Fix paths to type declarations in Vue package json

### DIFF
--- a/packages/sdk-vue/package.json
+++ b/packages/sdk-vue/package.json
@@ -43,12 +43,12 @@
   "files": [
     "dist/*"
   ],
-  "types": "./dist/index.d.ts",
-  "main": "./dist/vue-fusionauth.umd.cjs",
+  "types": "./dist/src/index.d.ts",
+  "main": "./dist/vue-fusionauth.js",
   "module": "./dist/vue-fusionauth.js",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist/src/index.d.ts",
       "import": "./dist/vue-fusionauth.js",
       "require": "./dist/vue-fusionauth.umd.cjs"
     },


### PR DESCRIPTION
## What is this PR and why do we need it?
The Vue SDK package.json specifies the wrong path the to the type declaration file. We need to correct this to get the benefits of TypeScript.

#### Pre-Merge Checklist (if applicable)
- [x] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.
