### PR TITLE
Add SDKConfig and SDKContext to core

### DIFF
--- a/packages/core/src/SDKConfig/SDKConfig.ts
+++ b/packages/core/src/SDKConfig/SDKConfig.ts
@@ -1,0 +1,69 @@
+/**
+ * Config for FusionAuth Web SDKs
+ */
+export type SDKConfig = {
+  /**
+   * The URL of the FusionAuth server.
+   */
+  serverUrl: string;
+
+  /**
+   * The client id of the application.
+   */
+  clientId: string;
+
+  /**
+   * The redirect URI of the application.
+   */
+  redirectUri: string;
+
+  /**
+   * The redirect URI for post-logout. Defaults the provided `redirectUri`.
+   */
+  postLogoutRedirectUri?: string;
+
+  /**
+   * Enables automatic token refreshing. Defaults to false.
+   */
+  shouldAutoRefresh?: boolean;
+
+  /**
+   * Enables the SDK to automatically handle fetching user info when logged in. Defaults to false.
+   */
+  shouldAutoFetchUserInfo?: boolean;
+
+  /**
+   * The number of seconds before the access token expiry when the auto refresh functionality kicks in if enabled. Default is 30.
+   */
+  autoRefreshSecondsBeforeExpiry?: number;
+
+  /**
+   * Callback function to be invoked with the `state` value upon redirect from login or register.
+   */
+  onRedirect?: (state?: string) => void;
+
+  /**
+   * The path to the login endpoint.
+   */
+  loginPath?: string;
+
+  /**
+   * The path to the register endpoint.
+   */
+  registerPath?: string;
+
+  /**
+   * The path to the logout endpoint.
+   */
+  logoutPath?: string;
+
+  /**
+   * The path to the token refresh endpoint.
+   */
+  tokenRefreshPath?: string;
+
+  /**
+   * The path to the me endpoint.
+   */
+  mePath?: string;
+};

--- a/packages/core/src/SDKConfig/index.ts
+++ b/packages/core/src/SDKConfig/index.ts
@@ -1,0 +1,1 @@
+export * from './SDKConfig';

--- a/packages/core/src/SDKContext/SDKContext.ts
+++ b/packages/core/src/SDKContext/SDKContext.ts
@@ -1,0 +1,75 @@
+/** The context provided by FusionAuth Web SDKs */
+export interface SDKContext {
+  /**
+   * Whether the user is logged in.
+   */
+  isLoggedIn: boolean;
+
+  /**
+   * Data fetched from the 'me' endpoint.
+   */
+  userInfo?: UserInfo;
+
+  /**
+   * Fetches user info from the 'me' endpoint.
+   * This is handled automatically if the SDK is configured with `shouldAutoFetchUserInfo`.
+   * @returns {Promise<UserInfo>}
+   */
+  fetchUserInfo: () => Promise<UserInfo>;
+
+  /**
+   * Indicates that the fetchUserInfo call is unresolved.
+   */
+  isFetchingUserInfo: boolean;
+
+  /**
+   * Error occurred while fetching userInfo.
+   */
+  error?: Error;
+
+  /**
+   * Initiates login flow.
+   * @param {string} [state] - Optional value to be echoed back to the SDK upon redirect.
+   */
+  startLogin: (state?: string) => void;
+
+  /**
+   * Initiates register flow.
+   * @param {string} [state] - Optional value to be echoed back to the SDK upon redirect.
+   */
+  startRegister: (state?: string) => void;
+
+  /**
+   * Initiates logout flow.
+   */
+  startLogout: () => void;
+
+  /**
+   * Refreshes the access token a single time.
+   * This is handled automatically if the SDK is configured with `shouldAutoRefresh`.
+   */
+  refreshToken: () => Promise<void>;
+
+  /**
+   * Initializes automatic access token refreshing.
+   * This is handled automatically if the SDK is configured with `shouldAutoRefresh`.
+   */
+  initAutoRefresh: () => void;
+}
+
+/**
+ * User information returned from FusionAuth.
+ */
+export type UserInfo = {
+  applicationId?: string;
+  email?: string;
+  email_verified?: boolean;
+  family_name?: string;
+  given_name?: string;
+  picture?: string;
+  roles?: any[];
+  sid?: string;
+  sub?: string;
+  tid?: string;
+  phone_number?: string;
+};

--- a/packages/core/src/SDKContext/index.ts
+++ b/packages/core/src/SDKContext/index.ts
@@ -1,0 +1,1 @@
+export * from './SDKContext';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,5 @@
 export * from './CookieHelpers';
 export * from './UrlHelper';
+export * from './SDKConfig';
+export * from './SDKContext';
 export * from './TokenRefresher';


### PR DESCRIPTION
## What is this PR and why do we need it?
#48 - Consolidate SDK config and context via core package.

These definitions will encompass the public API for the next major version release of each SDK.
- `SDKConfig` -- The configuration object needed to initialize each framework's main component.
- `SDKContext` -- The values and methods provided by each framework's main component.

These types are defined here, not implemented. We are planning to work backwards to get parity for each SDK.

#### Pre-Merge Checklist (if applicable)
- [x] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.
