### PR TITLE
Add missing core build step to react-publish-workflow

### DIFF
--- a/.github/workflows/publish-sdk-react.yml
+++ b/.github/workflows/publish-sdk-react.yml
@@ -17,6 +17,8 @@ jobs:
           cache: 'npm'
       - name: React SDK - Install packages
         run: yarn install --frozen-lockfile
+      - name: Build core package
+        run: yarn build:core
       - name: React SDK - Test
         run: yarn test:sdk-react
 


### PR DESCRIPTION
## What is this PR and why do we need it?
Our workflow dispatch failed because we were missing a step to build the core package before running the react tests. This should fix.

#### Pre-Merge Checklist (if applicable)
- [x] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.
