### PR TITLE
Fix typo in useFusionAuth jsdoc comment

### DIFF
--- a/packages/sdk-react/docs/interfaces/FusionAuthProviderConfig.FusionAuthProviderConfig.md
+++ b/packages/sdk-react/docs/interfaces/FusionAuthProviderConfig.FusionAuthProviderConfig.md
@@ -35,7 +35,7 @@ Only set this if you are hosting server that uses a custom name for the 'app.at_
 
 #### Defined in
 
-[packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts:69](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/cac50ddbffcd76ceead19379f380c6a35462497e/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts#L69)
+[packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts:69](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/70d5b677cad1a2b11d090d5c6c3e06a3a491f098/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts#L69)
 
 ---
 
@@ -47,7 +47,7 @@ The number of seconds before the access token expiry when the auto refresh funct
 
 #### Defined in
 
-[packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts:33](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/cac50ddbffcd76ceead19379f380c6a35462497e/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts#L33)
+[packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts:33](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/70d5b677cad1a2b11d090d5c6c3e06a3a491f098/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts#L33)
 
 ---
 
@@ -59,7 +59,7 @@ The client id of the application.
 
 #### Defined in
 
-[packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts:13](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/cac50ddbffcd76ceead19379f380c6a35462497e/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts#L13)
+[packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts:13](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/70d5b677cad1a2b11d090d5c6c3e06a3a491f098/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts#L13)
 
 ---
 
@@ -71,7 +71,7 @@ The path to the login endpoint.
 
 #### Defined in
 
-[packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts:43](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/cac50ddbffcd76ceead19379f380c6a35462497e/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts#L43)
+[packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts:43](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/70d5b677cad1a2b11d090d5c6c3e06a3a491f098/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts#L43)
 
 ---
 
@@ -83,7 +83,7 @@ The path to the logout endpoint.
 
 #### Defined in
 
-[packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts:53](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/cac50ddbffcd76ceead19379f380c6a35462497e/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts#L53)
+[packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts:53](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/70d5b677cad1a2b11d090d5c6c3e06a3a491f098/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts#L53)
 
 ---
 
@@ -95,7 +95,7 @@ The path to the me endpoint.
 
 #### Defined in
 
-[packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts:63](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/cac50ddbffcd76ceead19379f380c6a35462497e/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts#L63)
+[packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts:63](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/70d5b677cad1a2b11d090d5c6c3e06a3a491f098/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts#L63)
 
 ---
 
@@ -121,7 +121,7 @@ Callback function to be invoked with the `state` value upon redirect from login 
 
 #### Defined in
 
-[packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts:38](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/cac50ddbffcd76ceead19379f380c6a35462497e/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts#L38)
+[packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts:38](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/70d5b677cad1a2b11d090d5c6c3e06a3a491f098/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts#L38)
 
 ---
 
@@ -133,7 +133,7 @@ The redirect URI of the application.
 
 #### Defined in
 
-[packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts:18](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/cac50ddbffcd76ceead19379f380c6a35462497e/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts#L18)
+[packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts:18](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/70d5b677cad1a2b11d090d5c6c3e06a3a491f098/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts#L18)
 
 ---
 
@@ -145,7 +145,7 @@ The path to the register endpoint.
 
 #### Defined in
 
-[packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts:48](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/cac50ddbffcd76ceead19379f380c6a35462497e/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts#L48)
+[packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts:48](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/70d5b677cad1a2b11d090d5c6c3e06a3a491f098/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts#L48)
 
 ---
 
@@ -157,7 +157,7 @@ The URL of the server that performs the token exchange.
 
 #### Defined in
 
-[packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts:8](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/cac50ddbffcd76ceead19379f380c6a35462497e/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts#L8)
+[packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts:8](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/70d5b677cad1a2b11d090d5c6c3e06a3a491f098/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts#L8)
 
 ---
 
@@ -169,7 +169,7 @@ Enables the SDK to automatically handle fetching user info when logged in. Defau
 
 #### Defined in
 
-[packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts:28](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/cac50ddbffcd76ceead19379f380c6a35462497e/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts#L28)
+[packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts:28](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/70d5b677cad1a2b11d090d5c6c3e06a3a491f098/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts#L28)
 
 ---
 
@@ -181,7 +181,7 @@ Enables automatic token refreshing. Defaults to false.
 
 #### Defined in
 
-[packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts:23](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/cac50ddbffcd76ceead19379f380c6a35462497e/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts#L23)
+[packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts:23](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/70d5b677cad1a2b11d090d5c6c3e06a3a491f098/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts#L23)
 
 ---
 
@@ -193,4 +193,4 @@ The path to the token refresh endpoint.
 
 #### Defined in
 
-[packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts:58](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/cac50ddbffcd76ceead19379f380c6a35462497e/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts#L58)
+[packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts:58](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/70d5b677cad1a2b11d090d5c6c3e06a3a491f098/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts#L58)

--- a/packages/sdk-react/docs/interfaces/FusionAuthProviderContext.FusionAuthProviderContext.md
+++ b/packages/sdk-react/docs/interfaces/FusionAuthProviderContext.FusionAuthProviderContext.md
@@ -31,7 +31,7 @@ Error occurred while fetching userInfo.
 
 #### Defined in
 
-[packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts:30](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/cac50ddbffcd76ceead19379f380c6a35462497e/packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts#L30)
+[packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts:30](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/70d5b677cad1a2b11d090d5c6c3e06a3a491f098/packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts#L30)
 
 ---
 
@@ -52,7 +52,7 @@ This is handled automatically if the SDK is configured with `shouldAutoFetchUser
 
 #### Defined in
 
-[packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts:20](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/cac50ddbffcd76ceead19379f380c6a35462497e/packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts#L20)
+[packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts:20](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/70d5b677cad1a2b11d090d5c6c3e06a3a491f098/packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts#L20)
 
 ---
 
@@ -73,7 +73,7 @@ This is handled automatically if the SDK is configured with `shouldAutoRefresh`.
 
 #### Defined in
 
-[packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts:59](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/cac50ddbffcd76ceead19379f380c6a35462497e/packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts#L59)
+[packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts:59](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/70d5b677cad1a2b11d090d5c6c3e06a3a491f098/packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts#L59)
 
 ---
 
@@ -85,7 +85,7 @@ Indicates that the fetchUserInfo call is unresolved.
 
 #### Defined in
 
-[packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts:25](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/cac50ddbffcd76ceead19379f380c6a35462497e/packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts#L25)
+[packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts:25](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/70d5b677cad1a2b11d090d5c6c3e06a3a491f098/packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts#L25)
 
 ---
 
@@ -97,7 +97,7 @@ Whether the user is logged in.
 
 #### Defined in
 
-[packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts:8](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/cac50ddbffcd76ceead19379f380c6a35462497e/packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts#L8)
+[packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts:8](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/70d5b677cad1a2b11d090d5c6c3e06a3a491f098/packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts#L8)
 
 ---
 
@@ -118,7 +118,7 @@ This is handled automatically if the SDK is configured with `shouldAutoRefresh`.
 
 #### Defined in
 
-[packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts:53](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/cac50ddbffcd76ceead19379f380c6a35462497e/packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts#L53)
+[packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts:53](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/70d5b677cad1a2b11d090d5c6c3e06a3a491f098/packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts#L53)
 
 ---
 
@@ -144,7 +144,7 @@ Initiates login flow.
 
 #### Defined in
 
-[packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts:36](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/cac50ddbffcd76ceead19379f380c6a35462497e/packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts#L36)
+[packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts:36](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/70d5b677cad1a2b11d090d5c6c3e06a3a491f098/packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts#L36)
 
 ---
 
@@ -164,7 +164,7 @@ Initiates logout flow.
 
 #### Defined in
 
-[packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts:47](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/cac50ddbffcd76ceead19379f380c6a35462497e/packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts#L47)
+[packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts:47](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/70d5b677cad1a2b11d090d5c6c3e06a3a491f098/packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts#L47)
 
 ---
 
@@ -190,7 +190,7 @@ Initiates register flow.
 
 #### Defined in
 
-[packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts:42](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/cac50ddbffcd76ceead19379f380c6a35462497e/packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts#L42)
+[packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts:42](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/70d5b677cad1a2b11d090d5c6c3e06a3a491f098/packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts#L42)
 
 ---
 
@@ -202,4 +202,4 @@ Data fetched from the configured 'me' endpoint.
 
 #### Defined in
 
-[packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts:13](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/cac50ddbffcd76ceead19379f380c6a35462497e/packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts#L13)
+[packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts:13](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/70d5b677cad1a2b11d090d5c6c3e06a3a491f098/packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts#L13)

--- a/packages/sdk-react/docs/modules/FusionAuthProvider.md
+++ b/packages/sdk-react/docs/modules/FusionAuthProvider.md
@@ -28,7 +28,7 @@
 
 #### Defined in
 
-[packages/sdk-react/src/components/providers/FusionAuthProvider.tsx:9](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/cac50ddbffcd76ceead19379f380c6a35462497e/packages/sdk-react/src/components/providers/FusionAuthProvider.tsx#L9)
+[packages/sdk-react/src/components/providers/FusionAuthProvider.tsx:9](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/70d5b677cad1a2b11d090d5c6c3e06a3a491f098/packages/sdk-react/src/components/providers/FusionAuthProvider.tsx#L9)
 
 ---
 
@@ -36,7 +36,7 @@
 
 ▸ **useFusionAuth**(): [`FusionAuthProviderContext`](../interfaces/FusionAuthProviderContext.FusionAuthProviderContext.md)
 
-A hook that returns and object containing [`FusionAuthProviderContext`](#interfaces/FusionAuthProviderContext.FusionAuthProviderContext.md)
+A hook that returns `FusionAuthProviderContext`
 
 #### Returns
 
@@ -44,4 +44,4 @@ A hook that returns and object containing [`FusionAuthProviderContext`](#interfa
 
 #### Defined in
 
-[packages/sdk-react/src/components/providers/FusionAuthProvider.tsx:64](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/cac50ddbffcd76ceead19379f380c6a35462497e/packages/sdk-react/src/components/providers/FusionAuthProvider.tsx#L64)
+[packages/sdk-react/src/components/providers/FusionAuthProvider.tsx:64](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/70d5b677cad1a2b11d090d5c6c3e06a3a491f098/packages/sdk-react/src/components/providers/FusionAuthProvider.tsx#L64)

--- a/packages/sdk-react/src/components/providers/FusionAuthProvider.tsx
+++ b/packages/sdk-react/src/components/providers/FusionAuthProvider.tsx
@@ -59,7 +59,7 @@ const FusionAuthProvider: FC<
 };
 
 /**
- * A hook that returns and object containing [`FusionAuthProviderContext`](#interfaces/FusionAuthProviderContext.FusionAuthProviderContext.md)
+ * A hook that returns `FusionAuthProviderContext`
  */
 const useFusionAuth = () => useContext(FusionAuthContext);
 


### PR DESCRIPTION
## What is this PR and why do we need it?
This fixes a typo and bunk link in a jsdoc comment. The reason for the large diff is because I regenerated the docs folder.

#### Pre-Merge Checklist (if applicable)
- [x] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.
