### PR TITLE
React SDK v2.1.0

### DIFF
--- a/packages/sdk-react/CHANGES.md
+++ b/packages/sdk-react/CHANGES.md
@@ -1,5 +1,9 @@
 fusionauth-react-sdk Changes
 
+Changes in 2.1.0
+
+- `scope` has been added back to the `FusionAuthProviderConfig` to be more compatible with [FusionAuth v1.50](https://fusionauth.io/docs/release-notes/#version-1-50-0)
+
 Changes in 2.0.0
 
 Breaking changes were made to provide new configuration options. These options include enabling automatic SDK functionality vs writing your own implementation via methods exposed by the `useFusionAuth` hook. These changes are also aimed at using more consistent verbiage within the SDK documentation.

--- a/packages/sdk-react/docs/README.md
+++ b/packages/sdk-react/docs/README.md
@@ -224,7 +224,7 @@ Doing this will overwrite your file, but fix prettier's objections.
 
 ## Releases
 
-To perform a release to NPM, create a release on GitHub. That will automatically publish a release to GitHub.
+This package is released via GitHub actions.
 
 ## Upgrade Policy
 

--- a/packages/sdk-react/docs/interfaces/FusionAuthProviderConfig.FusionAuthProviderConfig.md
+++ b/packages/sdk-react/docs/interfaces/FusionAuthProviderConfig.FusionAuthProviderConfig.md
@@ -19,6 +19,7 @@ Config for FusionAuthProvider
 - [onRedirect](FusionAuthProviderConfig.FusionAuthProviderConfig.md#onredirect)
 - [redirectUri](FusionAuthProviderConfig.FusionAuthProviderConfig.md#redirecturi)
 - [registerPath](FusionAuthProviderConfig.FusionAuthProviderConfig.md#registerpath)
+- [scope](FusionAuthProviderConfig.FusionAuthProviderConfig.md#scope)
 - [serverUrl](FusionAuthProviderConfig.FusionAuthProviderConfig.md#serverurl)
 - [shouldAutoFetchUserInfo](FusionAuthProviderConfig.FusionAuthProviderConfig.md#shouldautofetchuserinfo)
 - [shouldAutoRefresh](FusionAuthProviderConfig.FusionAuthProviderConfig.md#shouldautorefresh)
@@ -35,7 +36,7 @@ Only set this if you are hosting server that uses a custom name for the 'app.at_
 
 #### Defined in
 
-[packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts:69](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/70d5b677cad1a2b11d090d5c6c3e06a3a491f098/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts#L69)
+[packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts:74](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/6f1de893735ee6b106ed805dd8ba2011e08e1cfc/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts#L74)
 
 ---
 
@@ -47,7 +48,7 @@ The number of seconds before the access token expiry when the auto refresh funct
 
 #### Defined in
 
-[packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts:33](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/70d5b677cad1a2b11d090d5c6c3e06a3a491f098/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts#L33)
+[packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts:38](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/6f1de893735ee6b106ed805dd8ba2011e08e1cfc/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts#L38)
 
 ---
 
@@ -59,7 +60,7 @@ The client id of the application.
 
 #### Defined in
 
-[packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts:13](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/70d5b677cad1a2b11d090d5c6c3e06a3a491f098/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts#L13)
+[packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts:13](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/6f1de893735ee6b106ed805dd8ba2011e08e1cfc/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts#L13)
 
 ---
 
@@ -71,7 +72,7 @@ The path to the login endpoint.
 
 #### Defined in
 
-[packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts:43](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/70d5b677cad1a2b11d090d5c6c3e06a3a491f098/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts#L43)
+[packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts:48](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/6f1de893735ee6b106ed805dd8ba2011e08e1cfc/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts#L48)
 
 ---
 
@@ -83,7 +84,7 @@ The path to the logout endpoint.
 
 #### Defined in
 
-[packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts:53](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/70d5b677cad1a2b11d090d5c6c3e06a3a491f098/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts#L53)
+[packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts:58](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/6f1de893735ee6b106ed805dd8ba2011e08e1cfc/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts#L58)
 
 ---
 
@@ -95,7 +96,7 @@ The path to the me endpoint.
 
 #### Defined in
 
-[packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts:63](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/70d5b677cad1a2b11d090d5c6c3e06a3a491f098/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts#L63)
+[packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts:68](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/6f1de893735ee6b106ed805dd8ba2011e08e1cfc/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts#L68)
 
 ---
 
@@ -121,7 +122,7 @@ Callback function to be invoked with the `state` value upon redirect from login 
 
 #### Defined in
 
-[packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts:38](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/70d5b677cad1a2b11d090d5c6c3e06a3a491f098/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts#L38)
+[packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts:43](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/6f1de893735ee6b106ed805dd8ba2011e08e1cfc/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts#L43)
 
 ---
 
@@ -133,7 +134,7 @@ The redirect URI of the application.
 
 #### Defined in
 
-[packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts:18](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/70d5b677cad1a2b11d090d5c6c3e06a3a491f098/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts#L18)
+[packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts:18](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/6f1de893735ee6b106ed805dd8ba2011e08e1cfc/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts#L18)
 
 ---
 
@@ -145,7 +146,19 @@ The path to the register endpoint.
 
 #### Defined in
 
-[packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts:48](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/70d5b677cad1a2b11d090d5c6c3e06a3a491f098/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts#L48)
+[packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts:53](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/6f1de893735ee6b106ed805dd8ba2011e08e1cfc/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts#L53)
+
+---
+
+### scope
+
+• **scope**: `string`
+
+The OAuth2 scope parameter passed to the `/oauth2/authorize` endpoint. If not specified fusionauth will default this to `openid offline_access`.
+
+#### Defined in
+
+[packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts:23](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/6f1de893735ee6b106ed805dd8ba2011e08e1cfc/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts#L23)
 
 ---
 
@@ -157,7 +170,7 @@ The URL of the server that performs the token exchange.
 
 #### Defined in
 
-[packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts:8](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/70d5b677cad1a2b11d090d5c6c3e06a3a491f098/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts#L8)
+[packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts:8](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/6f1de893735ee6b106ed805dd8ba2011e08e1cfc/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts#L8)
 
 ---
 
@@ -169,7 +182,7 @@ Enables the SDK to automatically handle fetching user info when logged in. Defau
 
 #### Defined in
 
-[packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts:28](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/70d5b677cad1a2b11d090d5c6c3e06a3a491f098/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts#L28)
+[packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts:33](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/6f1de893735ee6b106ed805dd8ba2011e08e1cfc/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts#L33)
 
 ---
 
@@ -181,7 +194,7 @@ Enables automatic token refreshing. Defaults to false.
 
 #### Defined in
 
-[packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts:23](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/70d5b677cad1a2b11d090d5c6c3e06a3a491f098/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts#L23)
+[packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts:28](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/6f1de893735ee6b106ed805dd8ba2011e08e1cfc/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts#L28)
 
 ---
 
@@ -193,4 +206,4 @@ The path to the token refresh endpoint.
 
 #### Defined in
 
-[packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts:58](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/70d5b677cad1a2b11d090d5c6c3e06a3a491f098/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts#L58)
+[packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts:63](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/6f1de893735ee6b106ed805dd8ba2011e08e1cfc/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts#L63)

--- a/packages/sdk-react/docs/interfaces/FusionAuthProviderContext.FusionAuthProviderContext.md
+++ b/packages/sdk-react/docs/interfaces/FusionAuthProviderContext.FusionAuthProviderContext.md
@@ -31,7 +31,7 @@ Error occurred while fetching userInfo.
 
 #### Defined in
 
-[packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts:30](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/70d5b677cad1a2b11d090d5c6c3e06a3a491f098/packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts#L30)
+[packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts:30](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/6f1de893735ee6b106ed805dd8ba2011e08e1cfc/packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts#L30)
 
 ---
 
@@ -52,7 +52,7 @@ This is handled automatically if the SDK is configured with `shouldAutoFetchUser
 
 #### Defined in
 
-[packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts:20](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/70d5b677cad1a2b11d090d5c6c3e06a3a491f098/packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts#L20)
+[packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts:20](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/6f1de893735ee6b106ed805dd8ba2011e08e1cfc/packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts#L20)
 
 ---
 
@@ -73,7 +73,7 @@ This is handled automatically if the SDK is configured with `shouldAutoRefresh`.
 
 #### Defined in
 
-[packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts:59](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/70d5b677cad1a2b11d090d5c6c3e06a3a491f098/packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts#L59)
+[packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts:59](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/6f1de893735ee6b106ed805dd8ba2011e08e1cfc/packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts#L59)
 
 ---
 
@@ -85,7 +85,7 @@ Indicates that the fetchUserInfo call is unresolved.
 
 #### Defined in
 
-[packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts:25](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/70d5b677cad1a2b11d090d5c6c3e06a3a491f098/packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts#L25)
+[packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts:25](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/6f1de893735ee6b106ed805dd8ba2011e08e1cfc/packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts#L25)
 
 ---
 
@@ -97,7 +97,7 @@ Whether the user is logged in.
 
 #### Defined in
 
-[packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts:8](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/70d5b677cad1a2b11d090d5c6c3e06a3a491f098/packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts#L8)
+[packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts:8](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/6f1de893735ee6b106ed805dd8ba2011e08e1cfc/packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts#L8)
 
 ---
 
@@ -118,7 +118,7 @@ This is handled automatically if the SDK is configured with `shouldAutoRefresh`.
 
 #### Defined in
 
-[packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts:53](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/70d5b677cad1a2b11d090d5c6c3e06a3a491f098/packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts#L53)
+[packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts:53](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/6f1de893735ee6b106ed805dd8ba2011e08e1cfc/packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts#L53)
 
 ---
 
@@ -144,7 +144,7 @@ Initiates login flow.
 
 #### Defined in
 
-[packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts:36](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/70d5b677cad1a2b11d090d5c6c3e06a3a491f098/packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts#L36)
+[packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts:36](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/6f1de893735ee6b106ed805dd8ba2011e08e1cfc/packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts#L36)
 
 ---
 
@@ -164,7 +164,7 @@ Initiates logout flow.
 
 #### Defined in
 
-[packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts:47](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/70d5b677cad1a2b11d090d5c6c3e06a3a491f098/packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts#L47)
+[packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts:47](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/6f1de893735ee6b106ed805dd8ba2011e08e1cfc/packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts#L47)
 
 ---
 
@@ -190,7 +190,7 @@ Initiates register flow.
 
 #### Defined in
 
-[packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts:42](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/70d5b677cad1a2b11d090d5c6c3e06a3a491f098/packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts#L42)
+[packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts:42](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/6f1de893735ee6b106ed805dd8ba2011e08e1cfc/packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts#L42)
 
 ---
 
@@ -202,4 +202,4 @@ Data fetched from the configured 'me' endpoint.
 
 #### Defined in
 
-[packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts:13](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/70d5b677cad1a2b11d090d5c6c3e06a3a491f098/packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts#L13)
+[packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts:13](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/6f1de893735ee6b106ed805dd8ba2011e08e1cfc/packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts#L13)

--- a/packages/sdk-react/docs/modules/FusionAuthProvider.md
+++ b/packages/sdk-react/docs/modules/FusionAuthProvider.md
@@ -28,7 +28,7 @@
 
 #### Defined in
 
-[packages/sdk-react/src/components/providers/FusionAuthProvider.tsx:9](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/70d5b677cad1a2b11d090d5c6c3e06a3a491f098/packages/sdk-react/src/components/providers/FusionAuthProvider.tsx#L9)
+[packages/sdk-react/src/components/providers/FusionAuthProvider.tsx:9](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/6f1de893735ee6b106ed805dd8ba2011e08e1cfc/packages/sdk-react/src/components/providers/FusionAuthProvider.tsx#L9)
 
 ---
 
@@ -44,4 +44,4 @@ A hook that returns `FusionAuthProviderContext`
 
 #### Defined in
 
-[packages/sdk-react/src/components/providers/FusionAuthProvider.tsx:64](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/70d5b677cad1a2b11d090d5c6c3e06a3a491f098/packages/sdk-react/src/components/providers/FusionAuthProvider.tsx#L64)
+[packages/sdk-react/src/components/providers/FusionAuthProvider.tsx:64](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/6f1de893735ee6b106ed805dd8ba2011e08e1cfc/packages/sdk-react/src/components/providers/FusionAuthProvider.tsx#L64)

--- a/packages/sdk-react/package.json
+++ b/packages/sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fusionauth/react-sdk",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": false,
   "description": "FusionAuth solves the problem of building essential security without adding risk or distracting from your primary application",
   "type": "module",

--- a/packages/sdk-react/src/components/providers/FusionAuthProvider.test.tsx
+++ b/packages/sdk-react/src/components/providers/FusionAuthProvider.test.tsx
@@ -43,6 +43,7 @@ describe('FusionAuthProvider', () => {
     expectedUrl.pathname = '/app/login';
     expectedUrl.searchParams.set('client_id', TEST_CONFIG.clientId);
     expectedUrl.searchParams.set('redirect_uri', TEST_CONFIG.redirectUri);
+    expectedUrl.searchParams.set('scope', TEST_CONFIG.scope!);
     expectedUrl.searchParams.set('state', stateValue);
 
     expect(mockedLocation.assign).toHaveBeenCalledWith(expectedUrl);
@@ -78,6 +79,10 @@ describe('FusionAuthProvider', () => {
     expectedUrl.pathname = '/app/register';
     expectedUrl.searchParams.set('client_id', TEST_CONFIG.clientId);
     expectedUrl.searchParams.set('redirect_uri', TEST_CONFIG.redirectUri);
+    expectedUrl.searchParams.set(
+      'scope',
+      'openid email profile offline_access',
+    );
     expectedUrl.searchParams.set('state', stateValue);
 
     expect(localStorage.getItem('fa-sdk-redirect-value')).toContain(stateValue); // this asserts that `state` was echoed back.

--- a/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts
+++ b/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts
@@ -18,6 +18,11 @@ export interface FusionAuthProviderConfig {
   redirectUri: string;
 
   /**
+   * The OAuth2 scope parameter passed to the `/oauth2/authorize` endpoint. If not specified fusionauth will default this to `openid offline_access`.
+   */
+  scope?: string;
+
+  /**
    * Enables automatic token refreshing. Defaults to false.
    */
   shouldAutoRefresh?: boolean;

--- a/packages/sdk-react/src/testing-tools/mocks/testConfig.ts
+++ b/packages/sdk-react/src/testing-tools/mocks/testConfig.ts
@@ -4,4 +4,5 @@ export const TEST_CONFIG: FusionAuthProviderConfig = {
   clientId: '85a03867-dccf-4882-adde-1a79aeec50df',
   serverUrl: 'http://localhost:9000',
   redirectUri: 'http://localhost',
+  scope: 'openid email profile offline_access',
 };


### PR DESCRIPTION
## What is this PR and why do we need it?
A small change for this version--we are adding back the `scope` parameter to make this compatible with [FusionAuth v1.50](https://fusionauth.io/docs/release-notes/#version-1-50-0)

* Add `scope` back to react config
* bump version to 1.1.0
* regenerate docs

#### Pre-Merge Checklist (if applicable)
- [x] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.