### PR TITLE
73 Remove Unused query-string Dependency from Vue SDK

### DIFF
--- a/packages/sdk-vue/package.json
+++ b/packages/sdk-vue/package.json
@@ -40,9 +40,6 @@
     "typedoc-plugin-markdown": "^3.17.1",
     "@fusionauth-sdk/core": "*"
   },
-  "dependencies": {
-    "query-string": "8.1.0"
-  },
   "files": [
     "dist/*"
   ],


### PR DESCRIPTION
## What is this PR and why do we need it?

This PR removes the unused `query-string` dependency from the Vue SDK as this particular SDK does not have any dependencies in use.

See ticket for details:  https://github.com/FusionAuth/fusionauth-javascript-sdk/issues/73

**To Test:** 

- Checkout branch and run `yarn` command
- Link Vue SDK to the Vue Quickstart application and ensure functionality has not changed

#### Pre-Merge Checklist (if applicable)

- [x] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.
