### PR TITLE
Angular sdk v1.0

### DIFF
--- a/packages/sdk-angular/CHANGES.md
+++ b/packages/sdk-angular/CHANGES.md
@@ -1,0 +1,12 @@
+@fusionauth/angular-sdk Changes
+
+Changes in 1.0.0
+
+Several enhancements are availabe on the `FusionAuthService`
+
+- `getUserInfoObservable` provides an API that Angular components can subscribe to. Provides an api for handling pending state, as well as callbacks for success and error.
+- Adds error handling to the get user info request.
+- `FusionAuthService` provides observable `isLoggedIn$` property that updates within the Angular change dectection system if the access token expires.
+- `shouldAutoRefresh` option for the SDK to automatically handle refreshing the access token. Defaults to `false`.
+- `scope` has been added back to the `FusionAuthProviderConfig` to be more compatible with [FusionAuth v1.50](https://fusionauth.io/docs/release-notes/#version-1-50-0)
+- Full API documentation with TypeDoc now available (see official README from NPM).

--- a/packages/sdk-angular/README.md
+++ b/packages/sdk-angular/README.md
@@ -3,23 +3,14 @@ An SDK for using FusionAuth in Angular applications.
 # Table of Contents
 
 -   [Overview](#overview)
-
 -   [Getting Started](#getting-started)
-
   -   [Installation](#installation)
-
 -   [Usage](#usage)
-
   -   [Pre-built buttons](#pre-built-buttons)
-
   -   [Service usage](#service-usage)
-
   -   [Known issues](#known-issues)
-
 -   [Quickstart](#quickstart)
-
 -   [Documentation](#documentation)
-
 -   [Releases](#releases)
 
 <!--

--- a/packages/sdk-angular/docs/.nojekyll
+++ b/packages/sdk-angular/docs/.nojekyll
@@ -1,0 +1,1 @@
+TypeDoc added this file to prevent GitHub Pages from using Jekyll. You can turn off this behavior by setting the `githubPages` option to false.

--- a/packages/sdk-angular/docs/README.md
+++ b/packages/sdk-angular/docs/README.md
@@ -1,0 +1,17 @@
+@fusionauth/angular-sdk / [Exports](modules.md)
+
+# FusionauthAngularSdk
+
+This library was generated with [Angular CLI](https://github.com/angular/angular-cli) version 17.2.0.
+
+## Build
+
+Run `ng build` to build the project. The build artifacts will be stored in the `dist/` directory.
+
+## Running unit tests
+
+Run `ng test` to execute the unit tests via [Karma](https://karma-runner.github.io).
+
+## Further help
+
+To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI Overview and Command Reference](https://angular.io/cli) page.

--- a/packages/sdk-angular/docs/classes/FusionAuthLoginButtonComponent.md
+++ b/packages/sdk-angular/docs/classes/FusionAuthLoginButtonComponent.md
@@ -1,0 +1,72 @@
+[@fusionauth/angular-sdk](../README.md) / [Exports](../modules.md) / FusionAuthLoginButtonComponent
+
+# Class: FusionAuthLoginButtonComponent
+
+## Table of contents
+
+### Constructors
+
+- [constructor](FusionAuthLoginButtonComponent.md#constructor)
+
+### Properties
+
+- [fusionAuth](FusionAuthLoginButtonComponent.md#fusionauth)
+- [state](FusionAuthLoginButtonComponent.md#state)
+
+### Methods
+
+- [login](FusionAuthLoginButtonComponent.md#login)
+
+## Constructors
+
+### constructor
+
+• **new FusionAuthLoginButtonComponent**(`fusionAuth`): [`FusionAuthLoginButtonComponent`](FusionAuthLoginButtonComponent.md)
+
+#### Parameters
+
+| Name         | Type                                        |
+| :----------- | :------------------------------------------ |
+| `fusionAuth` | [`FusionAuthService`](FusionAuthService.md) |
+
+#### Returns
+
+[`FusionAuthLoginButtonComponent`](FusionAuthLoginButtonComponent.md)
+
+#### Defined in
+
+[lib/components/fusionauth-login.button/fusion-auth-login-button.component.ts:12](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/53e4097ee736b5b67b1c6f60aea9b74238ada880/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/components/fusionauth-login.button/fusion-auth-login-button.component.ts#L12)
+
+## Properties
+
+### fusionAuth
+
+• `Private` **fusionAuth**: [`FusionAuthService`](FusionAuthService.md)
+
+#### Defined in
+
+[lib/components/fusionauth-login.button/fusion-auth-login-button.component.ts:12](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/53e4097ee736b5b67b1c6f60aea9b74238ada880/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/components/fusionauth-login.button/fusion-auth-login-button.component.ts#L12)
+
+---
+
+### state
+
+• **state**: `undefined` \| `string`
+
+#### Defined in
+
+[lib/components/fusionauth-login.button/fusion-auth-login-button.component.ts:10](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/53e4097ee736b5b67b1c6f60aea9b74238ada880/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/components/fusionauth-login.button/fusion-auth-login-button.component.ts#L10)
+
+## Methods
+
+### login
+
+▸ **login**(): `void`
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[lib/components/fusionauth-login.button/fusion-auth-login-button.component.ts:14](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/53e4097ee736b5b67b1c6f60aea9b74238ada880/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/components/fusionauth-login.button/fusion-auth-login-button.component.ts#L14)

--- a/packages/sdk-angular/docs/classes/FusionAuthLogoutButtonComponent.md
+++ b/packages/sdk-angular/docs/classes/FusionAuthLogoutButtonComponent.md
@@ -1,0 +1,61 @@
+[@fusionauth/angular-sdk](../README.md) / [Exports](../modules.md) / FusionAuthLogoutButtonComponent
+
+# Class: FusionAuthLogoutButtonComponent
+
+## Table of contents
+
+### Constructors
+
+- [constructor](FusionAuthLogoutButtonComponent.md#constructor)
+
+### Properties
+
+- [fusionAuth](FusionAuthLogoutButtonComponent.md#fusionauth)
+
+### Methods
+
+- [logout](FusionAuthLogoutButtonComponent.md#logout)
+
+## Constructors
+
+### constructor
+
+• **new FusionAuthLogoutButtonComponent**(`fusionAuth`): [`FusionAuthLogoutButtonComponent`](FusionAuthLogoutButtonComponent.md)
+
+#### Parameters
+
+| Name         | Type                                        |
+| :----------- | :------------------------------------------ |
+| `fusionAuth` | [`FusionAuthService`](FusionAuthService.md) |
+
+#### Returns
+
+[`FusionAuthLogoutButtonComponent`](FusionAuthLogoutButtonComponent.md)
+
+#### Defined in
+
+[lib/components/fusionauth-logout.button/fusion-auth-logout-button.component.ts:10](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/53e4097ee736b5b67b1c6f60aea9b74238ada880/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/components/fusionauth-logout.button/fusion-auth-logout-button.component.ts#L10)
+
+## Properties
+
+### fusionAuth
+
+• `Private` **fusionAuth**: [`FusionAuthService`](FusionAuthService.md)
+
+#### Defined in
+
+[lib/components/fusionauth-logout.button/fusion-auth-logout-button.component.ts:10](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/53e4097ee736b5b67b1c6f60aea9b74238ada880/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/components/fusionauth-logout.button/fusion-auth-logout-button.component.ts#L10)
+
+## Methods
+
+### logout
+
+▸ **logout**(): `void`
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[lib/components/fusionauth-logout.button/fusion-auth-logout-button.component.ts:12](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/53e4097ee736b5b67b1c6f60aea9b74238ada880/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/components/fusionauth-logout.button/fusion-auth-logout-button.component.ts#L12)

--- a/packages/sdk-angular/docs/classes/FusionAuthModule.md
+++ b/packages/sdk-angular/docs/classes/FusionAuthModule.md
@@ -1,0 +1,43 @@
+[@fusionauth/angular-sdk](../README.md) / [Exports](../modules.md) / FusionAuthModule
+
+# Class: FusionAuthModule
+
+## Table of contents
+
+### Constructors
+
+- [constructor](FusionAuthModule.md#constructor)
+
+### Methods
+
+- [forRoot](FusionAuthModule.md#forroot)
+
+## Constructors
+
+### constructor
+
+• **new FusionAuthModule**(): [`FusionAuthModule`](FusionAuthModule.md)
+
+#### Returns
+
+[`FusionAuthModule`](FusionAuthModule.md)
+
+## Methods
+
+### forRoot
+
+▸ **forRoot**(`fusionAuthConfig`): `ModuleWithProviders`\<[`FusionAuthModule`](FusionAuthModule.md)\>
+
+#### Parameters
+
+| Name               | Type                                                    |
+| :----------------- | :------------------------------------------------------ |
+| `fusionAuthConfig` | [`FusionAuthConfig`](../interfaces/FusionAuthConfig.md) |
+
+#### Returns
+
+`ModuleWithProviders`\<[`FusionAuthModule`](FusionAuthModule.md)\>
+
+#### Defined in
+
+[lib/fusion-auth.module.ts:22](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/53e4097ee736b5b67b1c6f60aea9b74238ada880/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.module.ts#L22)

--- a/packages/sdk-angular/docs/classes/FusionAuthRegisterButtonComponent.md
+++ b/packages/sdk-angular/docs/classes/FusionAuthRegisterButtonComponent.md
@@ -1,0 +1,72 @@
+[@fusionauth/angular-sdk](../README.md) / [Exports](../modules.md) / FusionAuthRegisterButtonComponent
+
+# Class: FusionAuthRegisterButtonComponent
+
+## Table of contents
+
+### Constructors
+
+- [constructor](FusionAuthRegisterButtonComponent.md#constructor)
+
+### Properties
+
+- [fusionAuth](FusionAuthRegisterButtonComponent.md#fusionauth)
+- [state](FusionAuthRegisterButtonComponent.md#state)
+
+### Methods
+
+- [register](FusionAuthRegisterButtonComponent.md#register)
+
+## Constructors
+
+### constructor
+
+• **new FusionAuthRegisterButtonComponent**(`fusionAuth`): [`FusionAuthRegisterButtonComponent`](FusionAuthRegisterButtonComponent.md)
+
+#### Parameters
+
+| Name         | Type                                        |
+| :----------- | :------------------------------------------ |
+| `fusionAuth` | [`FusionAuthService`](FusionAuthService.md) |
+
+#### Returns
+
+[`FusionAuthRegisterButtonComponent`](FusionAuthRegisterButtonComponent.md)
+
+#### Defined in
+
+[lib/components/fusionauth-register.button/fusion-auth-register-button.component.ts:12](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/53e4097ee736b5b67b1c6f60aea9b74238ada880/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/components/fusionauth-register.button/fusion-auth-register-button.component.ts#L12)
+
+## Properties
+
+### fusionAuth
+
+• `Private` **fusionAuth**: [`FusionAuthService`](FusionAuthService.md)
+
+#### Defined in
+
+[lib/components/fusionauth-register.button/fusion-auth-register-button.component.ts:12](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/53e4097ee736b5b67b1c6f60aea9b74238ada880/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/components/fusionauth-register.button/fusion-auth-register-button.component.ts#L12)
+
+---
+
+### state
+
+• **state**: `undefined` \| `string`
+
+#### Defined in
+
+[lib/components/fusionauth-register.button/fusion-auth-register-button.component.ts:10](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/53e4097ee736b5b67b1c6f60aea9b74238ada880/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/components/fusionauth-register.button/fusion-auth-register-button.component.ts#L10)
+
+## Methods
+
+### register
+
+▸ **register**(): `void`
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[lib/components/fusionauth-register.button/fusion-auth-register-button.component.ts:14](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/53e4097ee736b5b67b1c6f60aea9b74238ada880/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/components/fusionauth-register.button/fusion-auth-register-button.component.ts#L14)

--- a/packages/sdk-angular/docs/classes/FusionAuthService.md
+++ b/packages/sdk-angular/docs/classes/FusionAuthService.md
@@ -1,0 +1,245 @@
+[@fusionauth/angular-sdk](../README.md) / [Exports](../modules.md) / FusionAuthService
+
+# Class: FusionAuthService
+
+Service class to use with FusionAuth backend endpoints.
+
+## Table of contents
+
+### Constructors
+
+- [constructor](FusionAuthService.md#constructor)
+
+### Properties
+
+- [autoRefreshTimer](FusionAuthService.md#autorefreshtimer)
+- [core](FusionAuthService.md#core)
+- [isLoggedIn$](FusionAuthService.md#isloggedin$)
+- [isLoggedInSubject](FusionAuthService.md#isloggedinsubject)
+
+### Methods
+
+- [getUserInfo](FusionAuthService.md#getuserinfo)
+- [getUserInfoObservable](FusionAuthService.md#getuserinfoobservable)
+- [initAutoRefresh](FusionAuthService.md#initautorefresh)
+- [isLoggedIn](FusionAuthService.md#isloggedin)
+- [logout](FusionAuthService.md#logout)
+- [refreshToken](FusionAuthService.md#refreshtoken)
+- [startLogin](FusionAuthService.md#startlogin)
+- [startRegistration](FusionAuthService.md#startregistration)
+
+## Constructors
+
+### constructor
+
+• **new FusionAuthService**(`config`): [`FusionAuthService`](FusionAuthService.md)
+
+#### Parameters
+
+| Name     | Type                                                    |
+| :------- | :------------------------------------------------------ |
+| `config` | [`FusionAuthConfig`](../interfaces/FusionAuthConfig.md) |
+
+#### Returns
+
+[`FusionAuthService`](FusionAuthService.md)
+
+#### Defined in
+
+[lib/fusion-auth.service.ts:13](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/53e4097ee736b5b67b1c6f60aea9b74238ada880/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.ts#L13)
+
+## Properties
+
+### autoRefreshTimer
+
+• `Private` `Optional` **autoRefreshTimer**: `Timeout`
+
+#### Defined in
+
+[lib/fusion-auth.service.ts:10](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/53e4097ee736b5b67b1c6f60aea9b74238ada880/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.ts#L10)
+
+---
+
+### core
+
+• `Private` **core**: `T`
+
+#### Defined in
+
+[lib/fusion-auth.service.ts:9](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/53e4097ee736b5b67b1c6f60aea9b74238ada880/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.ts#L9)
+
+---
+
+### isLoggedIn$
+
+• **isLoggedIn$**: `Observable`\<`boolean`\>
+
+An observable representing whether the user is logged in.
+
+#### Defined in
+
+[lib/fusion-auth.service.ts:32](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/53e4097ee736b5b67b1c6f60aea9b74238ada880/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.ts#L32)
+
+---
+
+### isLoggedInSubject
+
+• `Private` **isLoggedInSubject**: `BehaviorSubject`\<`boolean`\>
+
+#### Defined in
+
+[lib/fusion-auth.service.ts:11](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/53e4097ee736b5b67b1c6f60aea9b74238ada880/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.ts#L11)
+
+## Methods
+
+### getUserInfo
+
+▸ **getUserInfo**(): `Promise`\<[`UserInfo`](../interfaces/UserInfo.md)\>
+
+Fetches userInfo from the 'me' endpoint.
+
+#### Returns
+
+`Promise`\<[`UserInfo`](../interfaces/UserInfo.md)\>
+
+**`Throws`**
+
+- if an error occurred while fetching.
+
+#### Defined in
+
+[lib/fusion-auth.service.ts:90](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/53e4097ee736b5b67b1c6f60aea9b74238ada880/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.ts#L90)
+
+---
+
+### getUserInfoObservable
+
+▸ **getUserInfoObservable**(`callbacks?`): `Observable`\<[`UserInfo`](../interfaces/UserInfo.md)\>
+
+Returns an observable request that fetches userInfo, and catches error.
+
+#### Parameters
+
+| Name                 | Type         |
+| :------------------- | :----------- |
+| `callbacks?`         | `Object`     |
+| `callbacks.onBegin?` | () => `void` |
+| `callbacks.onDone?`  | () => `void` |
+
+#### Returns
+
+`Observable`\<[`UserInfo`](../interfaces/UserInfo.md)\>
+
+#### Defined in
+
+[lib/fusion-auth.service.ts:62](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/53e4097ee736b5b67b1c6f60aea9b74238ada880/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.ts#L62)
+
+---
+
+### initAutoRefresh
+
+▸ **initAutoRefresh**(): `void`
+
+Initializes automatic access token refreshing.
+This is handled automatically if the SDK is configured with `shouldAutoRefresh`.
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[lib/fusion-auth.service.ts:51](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/53e4097ee736b5b67b1c6f60aea9b74238ada880/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.ts#L51)
+
+---
+
+### isLoggedIn
+
+▸ **isLoggedIn**(): `boolean`
+
+A function that returns whether the user is logged in. This returned value is non-observable.
+
+#### Returns
+
+`boolean`
+
+#### Defined in
+
+[lib/fusion-auth.service.ts:35](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/53e4097ee736b5b67b1c6f60aea9b74238ada880/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.ts#L35)
+
+---
+
+### logout
+
+▸ **logout**(): `void`
+
+Initiates logout flow.
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[lib/fusion-auth.service.ts:113](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/53e4097ee736b5b67b1c6f60aea9b74238ada880/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.ts#L113)
+
+---
+
+### refreshToken
+
+▸ **refreshToken**(): `Promise`\<`void`\>
+
+Refreshes the access token a single time.
+Automatic token refreshing can be enabled if the SDK is configured with `shouldAutoRefresh`.
+
+#### Returns
+
+`Promise`\<`void`\>
+
+#### Defined in
+
+[lib/fusion-auth.service.ts:43](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/53e4097ee736b5b67b1c6f60aea9b74238ada880/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.ts#L43)
+
+---
+
+### startLogin
+
+▸ **startLogin**(`state?`): `void`
+
+Initiates login flow.
+
+#### Parameters
+
+| Name     | Type     | Description                                                |
+| :------- | :------- | :--------------------------------------------------------- |
+| `state?` | `string` | Optional value to be echoed back to the SDK upon redirect. |
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[lib/fusion-auth.service.ts:98](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/53e4097ee736b5b67b1c6f60aea9b74238ada880/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.ts#L98)
+
+---
+
+### startRegistration
+
+▸ **startRegistration**(`state?`): `void`
+
+Initiates register flow.
+
+#### Parameters
+
+| Name     | Type     | Description                                                |
+| :------- | :------- | :--------------------------------------------------------- |
+| `state?` | `string` | Optional value to be echoed back to the SDK upon redirect. |
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[lib/fusion-auth.service.ts:106](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/53e4097ee736b5b67b1c6f60aea9b74238ada880/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.ts#L106)

--- a/packages/sdk-angular/docs/interfaces/FusionAuthConfig.md
+++ b/packages/sdk-angular/docs/interfaces/FusionAuthConfig.md
@@ -1,0 +1,180 @@
+[@fusionauth/angular-sdk](../README.md) / [Exports](../modules.md) / FusionAuthConfig
+
+# Interface: FusionAuthConfig
+
+Config for FusionAuth Angular SDK
+
+## Table of contents
+
+### Properties
+
+- [autoRefreshSecondsBeforeExpiry](FusionAuthConfig.md#autorefreshsecondsbeforeexpiry)
+- [clientId](FusionAuthConfig.md#clientid)
+- [loginPath](FusionAuthConfig.md#loginpath)
+- [logoutPath](FusionAuthConfig.md#logoutpath)
+- [mePath](FusionAuthConfig.md#mepath)
+- [onRedirect](FusionAuthConfig.md#onredirect)
+- [redirectUri](FusionAuthConfig.md#redirecturi)
+- [registerPath](FusionAuthConfig.md#registerpath)
+- [scope](FusionAuthConfig.md#scope)
+- [serverUrl](FusionAuthConfig.md#serverurl)
+- [shouldAutoRefresh](FusionAuthConfig.md#shouldautorefresh)
+- [tokenRefreshPath](FusionAuthConfig.md#tokenrefreshpath)
+
+## Properties
+
+### autoRefreshSecondsBeforeExpiry
+
+• `Optional` **autoRefreshSecondsBeforeExpiry**: `number`
+
+The number of seconds before the access token expiry when the auto refresh functionality kicks in if enabled. Default is 10.
+
+#### Defined in
+
+[lib/types.ts:33](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/53e4097ee736b5b67b1c6f60aea9b74238ada880/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L33)
+
+---
+
+### clientId
+
+• **clientId**: `string`
+
+The client id of the application.
+
+#### Defined in
+
+[lib/types.ts:13](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/53e4097ee736b5b67b1c6f60aea9b74238ada880/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L13)
+
+---
+
+### loginPath
+
+• `Optional` **loginPath**: `string`
+
+The path to the login endpoint.
+
+#### Defined in
+
+[lib/types.ts:43](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/53e4097ee736b5b67b1c6f60aea9b74238ada880/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L43)
+
+---
+
+### logoutPath
+
+• `Optional` **logoutPath**: `string`
+
+The path to the logout endpoint.
+
+#### Defined in
+
+[lib/types.ts:53](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/53e4097ee736b5b67b1c6f60aea9b74238ada880/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L53)
+
+---
+
+### mePath
+
+• `Optional` **mePath**: `string`
+
+The path to the me endpoint.
+
+#### Defined in
+
+[lib/types.ts:63](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/53e4097ee736b5b67b1c6f60aea9b74238ada880/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L63)
+
+---
+
+### onRedirect
+
+• `Optional` **onRedirect**: (`state?`: `string`) => `void`
+
+Callback function to be invoked with the `state` value upon redirect from login or register.
+
+#### Type declaration
+
+▸ (`state?`): `void`
+
+##### Parameters
+
+| Name     | Type     |
+| :------- | :------- |
+| `state?` | `string` |
+
+##### Returns
+
+`void`
+
+#### Defined in
+
+[lib/types.ts:38](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/53e4097ee736b5b67b1c6f60aea9b74238ada880/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L38)
+
+---
+
+### redirectUri
+
+• **redirectUri**: `string`
+
+The redirect URI of the application.
+
+#### Defined in
+
+[lib/types.ts:18](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/53e4097ee736b5b67b1c6f60aea9b74238ada880/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L18)
+
+---
+
+### registerPath
+
+• `Optional` **registerPath**: `string`
+
+The path to the register endpoint.
+
+#### Defined in
+
+[lib/types.ts:48](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/53e4097ee736b5b67b1c6f60aea9b74238ada880/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L48)
+
+---
+
+### scope
+
+• `Optional` **scope**: `string`
+
+The OAuth2 scope parameter passed to the `/oauth2/authorize` endpoint. If not specified fusionauth will default this to `openid offline_access`.
+
+#### Defined in
+
+[lib/types.ts:23](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/53e4097ee736b5b67b1c6f60aea9b74238ada880/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L23)
+
+---
+
+### serverUrl
+
+• **serverUrl**: `string`
+
+The URL of the server that performs the token exchange.
+
+#### Defined in
+
+[lib/types.ts:8](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/53e4097ee736b5b67b1c6f60aea9b74238ada880/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L8)
+
+---
+
+### shouldAutoRefresh
+
+• `Optional` **shouldAutoRefresh**: `boolean`
+
+Enables automatic token refreshing. Defaults to false.
+
+#### Defined in
+
+[lib/types.ts:28](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/53e4097ee736b5b67b1c6f60aea9b74238ada880/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L28)
+
+---
+
+### tokenRefreshPath
+
+• `Optional` **tokenRefreshPath**: `string`
+
+The path to the token refresh endpoint.
+
+#### Defined in
+
+[lib/types.ts:58](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/53e4097ee736b5b67b1c6f60aea9b74238ada880/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L58)

--- a/packages/sdk-angular/docs/interfaces/UserInfo.md
+++ b/packages/sdk-angular/docs/interfaces/UserInfo.md
@@ -1,0 +1,129 @@
+[@fusionauth/angular-sdk](../README.md) / [Exports](../modules.md) / UserInfo
+
+# Interface: UserInfo
+
+## Table of contents
+
+### Properties
+
+- [applicationId](UserInfo.md#applicationid)
+- [email](UserInfo.md#email)
+- [email_verified](UserInfo.md#email_verified)
+- [family_name](UserInfo.md#family_name)
+- [given_name](UserInfo.md#given_name)
+- [phone_number](UserInfo.md#phone_number)
+- [picture](UserInfo.md#picture)
+- [roles](UserInfo.md#roles)
+- [sid](UserInfo.md#sid)
+- [sub](UserInfo.md#sub)
+- [tid](UserInfo.md#tid)
+
+## Properties
+
+### applicationId
+
+• `Optional` **applicationId**: `string`
+
+#### Defined in
+
+[lib/types.ts:67](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/53e4097ee736b5b67b1c6f60aea9b74238ada880/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L67)
+
+---
+
+### email
+
+• `Optional` **email**: `string`
+
+#### Defined in
+
+[lib/types.ts:68](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/53e4097ee736b5b67b1c6f60aea9b74238ada880/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L68)
+
+---
+
+### email_verified
+
+• `Optional` **email_verified**: `boolean`
+
+#### Defined in
+
+[lib/types.ts:69](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/53e4097ee736b5b67b1c6f60aea9b74238ada880/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L69)
+
+---
+
+### family_name
+
+• `Optional` **family_name**: `string`
+
+#### Defined in
+
+[lib/types.ts:70](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/53e4097ee736b5b67b1c6f60aea9b74238ada880/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L70)
+
+---
+
+### given_name
+
+• `Optional` **given_name**: `string`
+
+#### Defined in
+
+[lib/types.ts:71](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/53e4097ee736b5b67b1c6f60aea9b74238ada880/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L71)
+
+---
+
+### phone_number
+
+• `Optional` **phone_number**: `string`
+
+#### Defined in
+
+[lib/types.ts:77](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/53e4097ee736b5b67b1c6f60aea9b74238ada880/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L77)
+
+---
+
+### picture
+
+• `Optional` **picture**: `string`
+
+#### Defined in
+
+[lib/types.ts:72](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/53e4097ee736b5b67b1c6f60aea9b74238ada880/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L72)
+
+---
+
+### roles
+
+• `Optional` **roles**: `any`[]
+
+#### Defined in
+
+[lib/types.ts:73](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/53e4097ee736b5b67b1c6f60aea9b74238ada880/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L73)
+
+---
+
+### sid
+
+• `Optional` **sid**: `string`
+
+#### Defined in
+
+[lib/types.ts:74](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/53e4097ee736b5b67b1c6f60aea9b74238ada880/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L74)
+
+---
+
+### sub
+
+• `Optional` **sub**: `string`
+
+#### Defined in
+
+[lib/types.ts:75](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/53e4097ee736b5b67b1c6f60aea9b74238ada880/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L75)
+
+---
+
+### tid
+
+• `Optional` **tid**: `string`
+
+#### Defined in
+
+[lib/types.ts:76](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/53e4097ee736b5b67b1c6f60aea9b74238ada880/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L76)

--- a/packages/sdk-angular/docs/modules.md
+++ b/packages/sdk-angular/docs/modules.md
@@ -1,0 +1,18 @@
+[@fusionauth/angular-sdk](README.md) / Exports
+
+# @fusionauth/angular-sdk
+
+## Table of contents
+
+### Classes
+
+- [FusionAuthLoginButtonComponent](classes/FusionAuthLoginButtonComponent.md)
+- [FusionAuthLogoutButtonComponent](classes/FusionAuthLogoutButtonComponent.md)
+- [FusionAuthModule](classes/FusionAuthModule.md)
+- [FusionAuthRegisterButtonComponent](classes/FusionAuthRegisterButtonComponent.md)
+- [FusionAuthService](classes/FusionAuthService.md)
+
+### Interfaces
+
+- [FusionAuthConfig](interfaces/FusionAuthConfig.md)
+- [UserInfo](interfaces/UserInfo.md)

--- a/packages/sdk-angular/package.json
+++ b/packages/sdk-angular/package.json
@@ -5,7 +5,8 @@
     "ng": "ng",
     "build": "ng build && cp README.md dist/fusionauth-angular-sdk/README.md",
     "test": "ng test --watch=false --browsers=ChromeHeadless",
-    "test:watch": "ng test"
+    "test:watch": "ng test",
+    "docs": "typedoc --plugin typedoc-plugin-markdown"
   },
   "private": false,
   "dependencies": {
@@ -17,15 +18,17 @@
     "@angular/platform-browser": "^17.2.0",
     "@angular/platform-browser-dynamic": "^17.2.0",
     "@angular/router": "^17.2.0",
-    "@fusionauth-sdk/core": "*",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.3"
   },
   "devDependencies": {
+    "@fusionauth-sdk/core": "*",
     "@angular-devkit/build-angular": "^17.2.3",
     "@angular/cli": "^17.2.0",
     "@angular/compiler-cli": "^17.2.0",
+    "typedoc": "^0.25.13",
+    "typedoc-plugin-markdown": "^3.17.1",
     "@types/jasmine": "~5.1.0",
     "jasmine-core": "~5.1.0",
     "karma": "~6.4.0",

--- a/packages/sdk-angular/projects/fusionauth-angular-sdk/ng-package.json
+++ b/packages/sdk-angular/projects/fusionauth-angular-sdk/ng-package.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../../../node_modules/ng-packagr/ng-package.schema.json",
+  "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
   "dest": "../../dist/fusionauth-angular-sdk",
   "lib": {
     "entryFile": "src/public-api.ts"

--- a/packages/sdk-angular/projects/fusionauth-angular-sdk/package.json
+++ b/packages/sdk-angular/projects/fusionauth-angular-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fusionauth/angular-sdk",
-  "version": "0.1.7",
+  "version": "1.0.0",
   "peerDependencies": {
     "@angular/common": "^17.2.0",
     "@angular/core": "^17.2.0",

--- a/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/core.ts
+++ b/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/core.ts
@@ -1,0 +1,265 @@
+// @ts-nocheck
+const u = Object.defineProperty;
+const d = (r, e, t) =>
+  e in r
+    ? u(r, e, { enumerable: !0, configurable: !0, writable: !0, value: t })
+    : (r[e] = t);
+const i = (r, e, t) => (d(r, typeof e != 'symbol' ? e + '' : e, t), t);
+class g {
+  constructor(e) {
+    i(this, 'serverUrl');
+    i(this, 'clientId');
+    i(this, 'redirectUri');
+    i(this, 'scope');
+    i(this, 'mePath');
+    i(this, 'loginPath');
+    i(this, 'registerPath');
+    i(this, 'logoutPath');
+    i(this, 'tokenRefreshPath');
+    (this.serverUrl = e.serverUrl),
+      (this.clientId = e.clientId),
+      (this.redirectUri = e.redirectUri),
+      (this.scope = e.scope),
+      (this.mePath = e.mePath ?? '/app/me'),
+      (this.loginPath = e.loginPath ?? '/app/login'),
+      (this.registerPath = e.registerPath ?? '/app/register'),
+      (this.logoutPath = e.logoutPath ?? '/app/logout'),
+      (this.tokenRefreshPath = e.tokenRefreshPath ?? '/app/refresh');
+  }
+  getMeUrl() {
+    return this.generateUrl(this.mePath);
+  }
+  getLoginUrl(e) {
+    return this.generateUrl(this.loginPath, {
+      client_id: this.clientId,
+      redirect_uri: this.redirectUri,
+      scope: this.scope,
+      state: e,
+    });
+  }
+  getRegisterUrl(e) {
+    return this.generateUrl(this.registerPath, {
+      client_id: this.clientId,
+      redirect_uri: this.redirectUri,
+      scope: this.scope,
+      state: e,
+    });
+  }
+  getLogoutUrl() {
+    return this.generateUrl(this.logoutPath, {
+      client_id: this.clientId,
+      post_logout_redirect_uri: this.redirectUri,
+    });
+  }
+  getTokenRefreshUrl() {
+    return this.generateUrl(this.tokenRefreshPath, {
+      client_id: this.clientId,
+    });
+  }
+  generateUrl(e, t) {
+    const s = new URL(this.serverUrl);
+    if (((s.pathname = e), t)) {
+      const n = this.generateURLSearchParams(t);
+      s.search = n.toString();
+    }
+    return s;
+  }
+  generateURLSearchParams(e) {
+    const t = new URLSearchParams();
+    return (
+      Object.entries(e).forEach(([s, n]) => {
+        n && t.append(s, n);
+      }),
+      t
+    );
+  }
+}
+class o {
+  /**
+   * Parses document.cookie for the access token expiration cookie value.
+   * @returns {(number | null)} The moment of expiration in milliseconds since epoch.
+   */
+  static getAccessTokenExpirationMoment(e = 'app.at_exp') {
+    const t = document.cookie
+        .split('; ')
+        .map(n => n.split('='))
+        .find(([n]) => n === e),
+      s = t == null ? void 0 : t[1];
+    return s ? parseInt(s) * 1e3 : null;
+  }
+}
+class p {
+  constructor(e) {
+    i(this, 'url');
+    this.url = e;
+  }
+  /** Refresh token a single time */
+  async refreshToken() {
+    const e = await fetch(this.url.href, {
+      method: 'POST',
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'text/plain',
+      },
+    });
+    if (!(e.status >= 200 && e.status < 300))
+      throw new Error('error refreshing access token in fusionauth');
+  }
+  /** Initializes continuous automatic token refresh. */
+  initAutoRefresh(e = 10, t) {
+    const s = o.getAccessTokenExpirationMoment(t);
+    if (!s) return;
+    const n = e * 1e3,
+      a = /* @__PURE__ */ new Date().getTime(),
+      h = s - n,
+      c = Math.max(h - a, 0);
+    return setTimeout(async () => {
+      try {
+        await this.refreshToken(), this.initAutoRefresh(e);
+      } catch (l) {
+        console.error(l);
+      }
+    }, c);
+  }
+}
+class m {
+  /**
+   * Schedules a callback to be invoked at the given moment.
+   * @param expirationMoment - the access token expiration moment in milliseconds since the epoch.
+   * @param onExpiration - the callback to be invoked at the `expirationMoment`.
+   */
+  static scheduleTokenExpirationCallback(e, t) {
+    const s = /* @__PURE__ */ new Date().getTime(),
+      n = e - s;
+    n > 0 && setTimeout(t, n);
+  }
+}
+class R {
+  constructor() {
+    i(this, 'REDIRECT_VALUE', 'fa-sdk-redirect-value');
+  }
+  handlePreRedirect(e) {
+    const t = `${this.generateRandomString()}:${e ?? ''}`;
+    localStorage.setItem(this.REDIRECT_VALUE, t);
+  }
+  handlePostRedirect(e) {
+    const t = this.stateValue ?? void 0;
+    e == null || e(t), localStorage.removeItem(this.REDIRECT_VALUE);
+  }
+  get didRedirect() {
+    return !!localStorage.getItem(this.REDIRECT_VALUE);
+  }
+  get stateValue() {
+    const e = localStorage.getItem(this.REDIRECT_VALUE);
+    if (!e) return null;
+    const [, ...t] = e.split(':');
+    return t.join(':');
+  }
+  generateRandomString() {
+    const e = new Uint32Array(28);
+    return (
+      window.crypto.getRandomValues(e),
+      Array.from(e, t => ('0' + t.toString(16)).substring(-2)).join('')
+    );
+  }
+}
+class T {
+  constructor(e) {
+    i(this, 'config');
+    i(this, 'urlHelper');
+    i(this, 'tokenRefresher');
+    i(this, 'redirectHelper', new R());
+    (this.config = e),
+      (this.urlHelper = new g({
+        serverUrl: e.serverUrl,
+        clientId: e.clientId,
+        redirectUri: e.redirectUri,
+        scope: e.scope,
+        mePath: e.mePath,
+        loginPath: e.loginPath,
+        registerPath: e.registerPath,
+        logoutPath: e.logoutPath,
+        tokenRefreshPath: e.tokenRefreshPath,
+      })),
+      (this.tokenRefresher = new p(this.urlHelper.getTokenRefreshUrl())),
+      this.scheduleTokenExpirationEvent();
+  }
+  startLogin(e) {
+    this.redirectHelper.handlePreRedirect(e),
+      window.location.assign(this.urlHelper.getLoginUrl(e));
+  }
+  startRegister(e) {
+    this.redirectHelper.handlePreRedirect(e),
+      window.location.assign(this.urlHelper.getRegisterUrl(e));
+  }
+  startLogout() {
+    window.location.assign(this.urlHelper.getLogoutUrl());
+  }
+  async fetchUserInfo() {
+    const e = await fetch(this.urlHelper.getMeUrl(), {
+      credentials: 'include',
+    });
+    if (!e.ok)
+      throw new Error(
+        `Unable to fetch userInfo in fusionauth. Request failed with status code ${e == null ? void 0 : e.status}`,
+      );
+    return await e.json();
+  }
+  async refreshToken() {
+    return await this.tokenRefresher.refreshToken();
+  }
+  initAutoRefresh() {
+    return this.tokenRefresher.initAutoRefresh(
+      this.config.autoRefreshSecondsBeforeExpiry,
+      this.config.accessTokenExpireCookieName,
+    );
+  }
+  handlePostRedirect(e) {
+    this.isLoggedIn &&
+      this.redirectHelper.didRedirect &&
+      this.redirectHelper.handlePostRedirect(e);
+  }
+  get isLoggedIn() {
+    return this.accessTokenExpirationMoment
+      ? this.accessTokenExpirationMoment > /* @__PURE__ */ new Date().getTime()
+      : !1;
+  }
+  get accessTokenExpirationMoment() {
+    return o.getAccessTokenExpirationMoment(
+      this.config.accessTokenExpireCookieName,
+    );
+  }
+  scheduleTokenExpirationEvent() {
+    this.accessTokenExpirationMoment &&
+      this.config.onTokenExpiration &&
+      m.scheduleTokenExpirationCallback(
+        this.accessTokenExpirationMoment,
+        this.config.onTokenExpiration,
+      );
+  }
+}
+function U() {
+  const r = /* @__PURE__ */ new Date();
+  r.setHours(r.getHours() + 1);
+  const e = r.getTime() / 1e3;
+  document.cookie = `app.at_exp=${e}`;
+}
+function P() {
+  document.cookie = 'app.at_exp=;expires=Thu, 01 Jan 1970 00:00:00 GMT';
+}
+function E(r) {
+  const e = {
+    ...window.location,
+    assign: r.fn(),
+  };
+  return r.spyOn(window, 'location', 'get').mockReturnValue(e), e;
+}
+export {
+  o as CookieHelpers,
+  T as SDKCore,
+  p as TokenRefresher,
+  g as UrlHelper,
+  U as mockIsLoggedIn,
+  E as mockWindowLocation,
+  P as removeAt_expCookie,
+};

--- a/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.spec.ts
+++ b/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.spec.ts
@@ -1,30 +1,115 @@
-import { UserInfo } from './types';
 import { FusionAuthConfig } from './types';
 import { FusionAuthService } from './fusion-auth.service';
+import { fakeAsync, flush, tick } from '@angular/core/testing';
+import { mockIsLoggedIn, removeAt_expCookie } from '@fusionauth-sdk/core';
+import { take } from 'rxjs';
 
 describe('FusionAuthService', () => {
-  let service: FusionAuthService;
+  afterEach(() => {
+    removeAt_expCookie();
+    localStorage.clear();
+  });
+
   const config: FusionAuthConfig = {
-    clientId: 'e9fdb985-9173-4e01-9d73-ac2d60d1dc8e',
-    loginPath: '/app/login',
+    clientId: 'a-client-id',
     redirectUri: 'http://my-app.com',
     serverUrl: 'http://localhost:9011',
   };
 
-  beforeEach(() => {
-    service = new FusionAuthService(config);
+  it('Can be configured to automatically handle getting userInfo', (done: DoneFn) => {
+    mockIsLoggedIn();
+
+    spyOn(window, 'fetch').and.resolveTo(
+      new Response(
+        JSON.stringify({
+          email: 'richard@test.com',
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const service = new FusionAuthService(config);
+
+    service.getUserInfoObservable().subscribe({
+      next: userInfo => {
+        expect(userInfo.email).toBe('richard@test.com');
+        done();
+      },
+    });
   });
 
-  it('should get user info', async () => {
-    const userInfo: UserInfo = {
-      email: 'richard@test.com',
-    };
+  it('Handles a failure to get userInfo', (done: DoneFn) => {
+    mockIsLoggedIn();
 
-    spyOn(window, 'fetch').and.resolveTo({
-      text: () => Promise.resolve(JSON.stringify(userInfo)),
-    } as Response);
+    const responseStatus = 400;
+    spyOn(window, 'fetch').and.resolveTo(
+      new Response(null, { status: responseStatus }),
+    );
 
-    const fetchedUserInfo = await service.getUserInfo();
-    expect(fetchedUserInfo).toEqual(userInfo);
+    const service = new FusionAuthService(config);
+
+    service.getUserInfoObservable().subscribe({
+      error: error => {
+        expect(error?.message).toBe(
+          `Unable to fetch userInfo in fusionauth. Request failed with status code ${responseStatus}`,
+        );
+        done();
+      },
+    });
+  });
+
+  it("Contains an observable 'isLoggedin$' property that becomes false as the access token expires.", fakeAsync(() => {
+    mockIsLoggedIn(); // sets `app.at_exp` cookie so user is logged in for 1 hour.
+
+    const service = new FusionAuthService(config);
+
+    tick(60 * 59 * 1000);
+    service.isLoggedIn$.pipe(take(1)).subscribe(isLoggedIn => {
+      expect(isLoggedIn).toBe(true);
+    });
+
+    tick(60 * 1000); // access token expires
+    service.isLoggedIn$.pipe(take(1)).subscribe(isLoggedIn => {
+      expect(isLoggedIn).toBe(false);
+    });
+
+    flush();
+  }));
+
+  it('Can be configured to automatically refresh the access token', () => {
+    mockIsLoggedIn();
+    const spy = spyOn(FusionAuthService.prototype, 'initAutoRefresh');
+
+    const service = new FusionAuthService({
+      ...config,
+      shouldAutoRefresh: true,
+    });
+
+    expect(service.isLoggedIn()).toBe(true);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("Does not invoke 'initAutoRefresh' if the user is not logged in", () => {
+    const spy = spyOn(FusionAuthService.prototype, 'initAutoRefresh');
+    const service = new FusionAuthService({
+      ...config,
+      shouldAutoRefresh: true,
+    });
+
+    expect(service.isLoggedIn()).toBe(false);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("Invokes an 'onRedirect' callback", () => {
+    mockIsLoggedIn();
+
+    const stateValue = '/welcome-page';
+    localStorage.setItem('fa-sdk-redirect-value', `abc123:${stateValue}`);
+
+    const onRedirect = jasmine.createSpy('onRedirectSpy');
+
+    new FusionAuthService({ ...config, onRedirect });
+
+    expect(onRedirect).toHaveBeenCalledWith('/welcome-page');
   });
 });

--- a/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts
+++ b/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts
@@ -1,16 +1,65 @@
+/**
+ * Config for FusionAuth Angular SDK
+ */
 export interface FusionAuthConfig {
+  /**
+   * The URL of the server that performs the token exchange.
+   */
   serverUrl: string;
-  clientId: string;
-  redirectUri?: string;
 
-  /** The number of seconds before the access token expiry when the auto refresh functionality kicks in if enabled. Default is 10. */
-  autoRefreshSecondsBeforeExpiry?: number;
-  /** Enables automatic token refreshing. Defaults to false. */
+  /**
+   * The client id of the application.
+   */
+  clientId: string;
+
+  /**
+   * The redirect URI of the application.
+   */
+  redirectUri: string;
+
+  /**
+   * The OAuth2 scope parameter passed to the `/oauth2/authorize` endpoint. If not specified fusionauth will default this to `openid offline_access`.
+   */
+  scope?: string;
+
+  /**
+   * Enables automatic token refreshing. Defaults to false.
+   */
   shouldAutoRefresh?: boolean;
+
+  /**
+   * The number of seconds before the access token expiry when the auto refresh functionality kicks in if enabled. Default is 10.
+   */
+  autoRefreshSecondsBeforeExpiry?: number;
+
+  /**
+   * Callback function to be invoked with the `state` value upon redirect from login or register.
+   */
+  onRedirect?: (state?: string) => void;
+
+  /**
+   * The path to the login endpoint.
+   */
   loginPath?: string;
-  logoutPath?: string;
+
+  /**
+   * The path to the register endpoint.
+   */
   registerPath?: string;
+
+  /**
+   * The path to the logout endpoint.
+   */
+  logoutPath?: string;
+
+  /**
+   * The path to the token refresh endpoint.
+   */
   tokenRefreshPath?: string;
+
+  /**
+   * The path to the me endpoint.
+   */
   mePath?: string;
 }
 

--- a/packages/sdk-angular/projects/fusionauth-angular-sdk/tsconfig.lib.json
+++ b/packages/sdk-angular/projects/fusionauth-angular-sdk/tsconfig.lib.json
@@ -6,7 +6,7 @@
     "declaration": true,
     "declarationMap": true,
     "inlineSources": true,
-    "types": []
+    "types": ["node"]
   },
   "exclude": ["**/*.spec.ts"]
 }

--- a/packages/sdk-angular/tsconfig.json
+++ b/packages/sdk-angular/tsconfig.json
@@ -34,5 +34,10 @@
     "strictInjectionParameters": true,
     "strictInputAccessModifiers": true,
     "strictTemplates": true
+  },
+  "typedocOptions": {
+    "plugin": ["typedoc-plugin-markdown"],
+    "entryPoints": ["projects/fusionauth-angular-sdk/src/public-api.ts"],
+    "out": "docs"
   }
 }


### PR DESCRIPTION
## What is this PR and why do we need it?
#78 This brings the Angular SDK to parity with React v2.0 and Vue v1.0.
It includes observable properties for `userInfo`, `isLoggedIn`, and `error` and the option to configure with automatic token refresh.

- Adds TypeDoc for generated full api documentation.
- Corresponding quickstart PR to be merged in lockstep with this: (https://github.com/FusionAuth/fusionauth-quickstart-javascript-angular-web/pull/22)
- `CHANGES.MD` added.
- Bumps version number to `1.0.0`


#### Pre-Merge Checklist (if applicable)
- [x] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.
