### PR TITLE
Fix indentation for Table of Contents on vue README

### DIFF
--- a/packages/sdk-vue/README.md
+++ b/packages/sdk-vue/README.md
@@ -12,11 +12,11 @@ An SDK for using FusionAuth in Vue applications.
   - [UI Components](#ui-components)
     - [Protecting Content](#protecting-content)
     - [Pre-built buttons](#pre-built-buttons)
-  - [Quickstart](#quickstart)
-  - [Documentation](#documentation)
-  - [Known Issues](#known-issues)
-  - [Releases](#releases)
-  - [Upgrade Policy](#upgrade-policy)
+- [Quickstart](#quickstart)
+- [Documentation](#documentation)
+- [Known Issues](#known-issues)
+- [Releases](#releases)
+- [Upgrade Policy](#upgrade-policy)
 
 <!--
 this tag, and the corresponding end tag, are used to delineate what is pulled into the FusionAuth docs site (the client libraries pages). Don't remove unless you also change the docs site.


### PR DESCRIPTION
## Fixing the indentation for Table of Contents on the vue README
The indentation for this homepage is out of whack

Fixing this 👇
<img width="797" alt="image" src="https://github.com/FusionAuth/fusionauth-javascript-sdk/assets/49047386/5967f43d-4b17-45c0-a1a1-fe7d7ce62eb4">