### PR TITLE
Fix typo in Angular changelog

### DIFF
--- a/packages/sdk-angular/CHANGES.md
+++ b/packages/sdk-angular/CHANGES.md
@@ -1,6 +1,6 @@
 @fusionauth/angular-sdk Changes
 
-Changes in 2.1.2
+Changes in 1.0.2
 
 - Adds `onAutoRefreshFailure` option to `FusionAuthConfig`.
 - _Bug fix_ `isLoggedIn$` observable property is set to `false` after token refresh. [See issue #82](https://github.com/FusionAuth/fusionauth-javascript-sdk/issues/82)


### PR DESCRIPTION
## Fix typo in Angular changelog
Correcting the version number to 1.0.2

#### Pre-Merge Checklist (if applicable)
- [x] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.