### PR TITLE
[Angular] SSR support

### DIFF
--- a/packages/core/src/CookieHelpers/CookieHelpers.test.ts
+++ b/packages/core/src/CookieHelpers/CookieHelpers.test.ts
@@ -24,9 +24,6 @@ describe('getAccessTokenExpirationMoment', () => {
     document.cookie = `${cookieName}=${exp}`;
 
     expect(getAccessTokenExpirationMoment(cookieName)).toBe(1200000);
-
-    document.cookie =
-      cookieName + '=; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT;';
   });
 
   it('Will get the value from a cookieAdapter if one is passed in', () => {

--- a/packages/core/src/CookieHelpers/CookieHelpers.ts
+++ b/packages/core/src/CookieHelpers/CookieHelpers.ts
@@ -2,7 +2,7 @@
  * Gets the `app.at_exp` cookie and converts it to milliseconds since epoch.
  * Returns -1 if the cookie is not present.
  * @param cookieName - defaults to `app.at_exp`.
- * @param adapter - SSR frameworks like Nuxt and Next will pass in an adapter.
+ * @param adapter - SSR frameworks like Nuxt, Next, and angular/ssr will pass in an adapter.
  */
 export function getAccessTokenExpirationMoment(
   cookieName: string = 'app.at_exp',

--- a/packages/sdk-angular/.eslintrc.json
+++ b/packages/sdk-angular/.eslintrc.json
@@ -1,4 +1,7 @@
 {
   "root": false,
-  "extends": "../../.eslintrc"
+  "extends": "../../.eslintrc",
+  "rules": {
+    "@typescript-eslint/ban-types": "off"
+  }
 }

--- a/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/SSRCookieAdapter.ts
+++ b/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/SSRCookieAdapter.ts
@@ -1,0 +1,23 @@
+// import { CookieAdapter } from '@fusionauth-sdk/core';
+
+/** An adapter class that supports accessing cookies with SSR */
+export class SSRCookieAdapter /* implements CookieAdapter */ {
+  constructor(private isBrowser: boolean) {}
+
+  at_exp(cookieName: string = 'app.at_exp') {
+    if (!this.isBrowser) {
+      return;
+    }
+
+    try {
+      const expCookie = document.cookie
+        .split('; ')
+        .map(c => c.split('='))
+        .find(([name]) => name === cookieName);
+      return expCookie?.[1];
+    } catch (error) {
+      console.error('Error within the SSRCookieAdapter: ', error);
+      return -1;
+    }
+  }
+}

--- a/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.module.ts
+++ b/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.module.ts
@@ -1,6 +1,7 @@
 import { ModuleWithProviders, NgModule } from '@angular/core';
 import { FusionAuthConfig } from './types';
 import { FusionAuthService } from './fusion-auth.service';
+import { FUSIONAUTH_SERVICE_CONFIG } from './injectionToken';
 import { FusionAuthLoginButtonComponent } from './components/fusionauth-login.button/fusion-auth-login-button.component';
 import { FusionAuthLogoutButtonComponent } from './components/fusionauth-logout.button/fusion-auth-logout-button.component';
 import { FusionAuthRegisterButtonComponent } from './components/fusionauth-register.button/fusion-auth-register-button.component';
@@ -25,10 +26,8 @@ export class FusionAuthModule {
     return {
       ngModule: FusionAuthModule,
       providers: [
-        {
-          provide: FusionAuthService,
-          useValue: new FusionAuthService(fusionAuthConfig),
-        },
+        { provide: FUSIONAUTH_SERVICE_CONFIG, useValue: fusionAuthConfig },
+        FusionAuthService,
       ],
     };
   }

--- a/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.ts
+++ b/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.ts
@@ -1,21 +1,33 @@
-import { SDKCore } from './core';
-import { FusionAuthConfig, UserInfo } from './types';
+import { Injectable, Inject, PLATFORM_ID } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
 import { Observable, catchError, BehaviorSubject } from 'rxjs';
+
+import { SDKCore } from './core';
+import { SSRCookieAdapter } from './SSRCookieAdapter';
+import { FusionAuthConfig, UserInfo } from './types';
+import { FUSIONAUTH_SERVICE_CONFIG } from './injectionToken';
 
 /**
  * Service class to use with FusionAuth backend endpoints.
  */
+@Injectable({
+  providedIn: 'root',
+})
 export class FusionAuthService {
   private core: SDKCore;
   private autoRefreshTimer?: NodeJS.Timeout;
   private isLoggedInSubject: BehaviorSubject<boolean>;
 
-  constructor(config: FusionAuthConfig) {
+  constructor(
+    @Inject(FUSIONAUTH_SERVICE_CONFIG) config: FusionAuthConfig,
+    @Inject(PLATFORM_ID) platformId: Object,
+  ) {
     this.core = new SDKCore({
       ...config,
       onTokenExpiration: () => {
         this.isLoggedInSubject.next(false);
       },
+      cookieAdapter: new SSRCookieAdapter(isPlatformBrowser(platformId)),
     });
 
     this.isLoggedInSubject = new BehaviorSubject(this.core.isLoggedIn);

--- a/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/injectionToken.ts
+++ b/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/injectionToken.ts
@@ -1,0 +1,6 @@
+import { InjectionToken } from '@angular/core';
+import { FusionAuthConfig } from './types';
+
+export const FUSIONAUTH_SERVICE_CONFIG = new InjectionToken<FusionAuthConfig>(
+  'FUSIONAUTH_SERVICE_CONFIG',
+);


### PR DESCRIPTION
## What is this PR and why do we need it?
#108 Adds SSR support to the Angular SDK.

Unlike the Nuxt and Next, No additional configuration will be needed from users of the Angular SDK. You should be able to use the `@fusionauth/angular-sdk` package in an angular SSR project without issues.

**Testing**
I set up an Angular SSR app. [Here is the repo](https://github.com/JakeLo123/ng-ssr/tree/fa-sdk-ssr) in case whomever is testing would like to use it. Make sure you are on the `fa-sdk-ssr` branch as `main` does not have `@fusionauth/angular-sdk` configured. Or feel free to do your own thing.

#### Pre-Merge Checklist (if applicable)
- [x] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.
