### PR TITLE
111 Setup Playwright and Add Cookies Tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,8 @@ yarn-error.log
 .eslintcache
 packages/sdk-angular/.angular/cache
 tsconfig.tsbuildinfo
+
+test-results
+playwright-report
+blob-report
+playwright/.cache

--- a/e2e/pages/common.page.ts
+++ b/e2e/pages/common.page.ts
@@ -1,0 +1,48 @@
+import { Locator, Page, expect } from '@playwright/test';
+
+const Locators = {
+  logInBtn: 'role=button[name="Login"]',
+  emailInput: 'role=textbox[name="Email"]',
+  passwordInput: 'role=textbox[name="Password"]',
+  submitBtn: 'role=button[name="Submit"]',
+  createAccountBtn: 'role=button[name="create a new account"]',
+  registerBtn: 'role=button[name="Register"]',
+  logOutBtn: 'role=button[name="Logout"]',
+} as const;
+
+export class quickstartPage {
+  readonly page: Page;
+  readonly locators: Record<string, Locator>;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.locators = Object.keys(Locators).reduce((acc, key) => {
+      acc[key] = page.locator((Locators as Record<string, string>)[key]);
+      return acc;
+    }, {});
+  }
+
+  async navToLogIn() {
+    await this.locators.logInBtn.nth(0).click();
+    await expect(this.locators.emailInput).toBeVisible();
+  }
+
+  async authenticate() {
+    await this.locators.emailInput.click();
+    await this.locators.emailInput.clear();
+    await this.locators.emailInput.fill('richard@example.com');
+    await this.locators.passwordInput.click();
+    await this.locators.passwordInput.clear();
+    await this.locators.passwordInput.fill('password');
+    await this.locators.submitBtn.click();
+  }
+
+  async navToRegister() {
+    await this.locators.createAccountBtn.click();
+    await expect(this.locators.registerBtn).toBeVisible();
+  }
+  async logOut() {
+    await this.locators.logOutBtn.click();
+    await expect(this.locators.logInBtn.nth(0)).toBeVisible();
+  }
+}

--- a/e2e/pages/common.page.ts
+++ b/e2e/pages/common.page.ts
@@ -10,16 +10,21 @@ const Locators = {
   logOutBtn: 'role=button[name="Logout"]',
 } as const;
 
+type LocatorsKey = keyof typeof Locators;
+
 export class quickstartPage {
   readonly page: Page;
-  readonly locators: Record<string, Locator>;
+  readonly locators: Record<LocatorsKey, Locator>;
 
   constructor(page: Page) {
     this.page = page;
-    this.locators = Object.keys(Locators).reduce((acc, key) => {
-      acc[key] = page.locator((Locators as Record<string, string>)[key]);
-      return acc;
-    }, {});
+    this.locators = Object.keys(Locators).reduce(
+      (acc, key) => {
+        acc[key as LocatorsKey] = page.locator(Locators[key as LocatorsKey]);
+        return acc;
+      },
+      {} as Record<LocatorsKey, Locator>,
+    );
   }
 
   async navToLogIn() {
@@ -41,6 +46,7 @@ export class quickstartPage {
     await this.locators.createAccountBtn.click();
     await expect(this.locators.registerBtn).toBeVisible();
   }
+
   async logOut() {
     await this.locators.logOutBtn.click();
     await expect(this.locators.logInBtn.nth(0)).toBeVisible();

--- a/e2e/tests/cookies.test.ts
+++ b/e2e/tests/cookies.test.ts
@@ -1,0 +1,63 @@
+import { Page, test, BrowserContext, expect, Cookie } from '@playwright/test';
+import { quickstartPage } from '../pages/common.page';
+
+test.describe('Login Endpoint Tests', () => {
+  let page: Page;
+  let quickstart: quickstartPage;
+  let browserContext: BrowserContext;
+
+  test.beforeAll(async ({ browser }) => {
+    browserContext = await browser.newContext();
+    page = await browserContext.newPage();
+    quickstart = new quickstartPage(page);
+    await page.goto('/');
+    await quickstart.navToLogIn();
+  });
+
+  test.afterAll(async () => {
+    await page.close();
+    await browserContext.close();
+  });
+
+  const checkCookieExistsAndHttpOnly = (
+    cookies: Cookie[],
+    name: string,
+    httpOnly: boolean,
+  ) => {
+    const cookie = cookies.find(cookie => cookie.name === name);
+    expect(cookie).toBeDefined();
+    expect(cookie?.httpOnly).toBe(httpOnly);
+  };
+
+  const checkCookieDoesNotExist = (cookies: Cookie[], name: string) => {
+    const cookie = cookies.find(cookie => cookie.name === name);
+    expect(cookie).toBeUndefined();
+  };
+
+  test('Unauthenticated Cookies', async () => {
+    const cookies = await browserContext.cookies();
+    checkCookieDoesNotExist(cookies, 'app.at');
+    checkCookieDoesNotExist(cookies, 'app.at_exp');
+    checkCookieDoesNotExist(cookies, 'app.idt');
+    checkCookieDoesNotExist(cookies, 'app.rt');
+  });
+
+  test('Authenticated Cookies', async () => {
+    await quickstart.authenticate();
+    const cookies = await browserContext.cookies();
+    checkCookieExistsAndHttpOnly(cookies, 'app.at', true);
+    checkCookieExistsAndHttpOnly(cookies, 'app.at_exp', false);
+    checkCookieExistsAndHttpOnly(cookies, 'app.idt', false);
+    checkCookieExistsAndHttpOnly(cookies, 'app.rt', true);
+  });
+
+  test('Post Logout Cookies', async () => {
+    await quickstart.authenticate();
+    await quickstart.logOut();
+    const cookies = await browserContext.cookies();
+    checkCookieDoesNotExist(cookies, 'app.at');
+    checkCookieDoesNotExist(cookies, 'app.at_exp');
+    checkCookieDoesNotExist(cookies, 'app.idt');
+    checkCookieDoesNotExist(cookies, 'app.rt');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   ],
   "devDependencies": {
     "@playwright/test": "^1.44.1",
+    "playwright": "^1.44.1",
     "@typescript-eslint/eslint-plugin": "^7.2.0",
     "@typescript-eslint/parser": "^7.2.0",
     "eslint": "^8.57.0",
@@ -55,8 +56,5 @@
   "lint-staged": {
     "*.{ts,tsx}": "eslint --cache --fix",
     "*.{js,css,md,ts,tsx,yml}": "prettier --write"
-  },
-  "dependencies": {
-    "playwright": "^1.44.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "packages/sdk-vue"
   ],
   "devDependencies": {
+    "@playwright/test": "^1.44.1",
     "@typescript-eslint/eslint-plugin": "^7.2.0",
     "@typescript-eslint/parser": "^7.2.0",
     "eslint": "^8.57.0",
@@ -45,6 +46,7 @@
     "test:sdk-angular": "yarn workspace sdk-angular-workspace test",
     "test:sdk-react": "yarn workspace @fusionauth/react-sdk test",
     "test:sdk-vue": "yarn workspace @fusionauth/vue-sdk test",
+    "test:e2e": "yarn playwright test",
     "lint:fix": "eslint . --ext .ts,.tsx --fix",
     "lint:check": "eslint . --ext .ts,.tsx --max-warnings 0",
     "format:fix": "prettier --write .",
@@ -53,5 +55,8 @@
   "lint-staged": {
     "*.{ts,tsx}": "eslint --cache --fix",
     "*.{js,css,md,ts,tsx,yml}": "prettier --write"
+  },
+  "dependencies": {
+    "playwright": "^1.44.1"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,55 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// require('dotenv').config();
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: './e2e',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: 9,
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: 'http://localhost:3000',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    screenshot: 'on',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2015,6 +2015,13 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
+"@playwright/test@^1.44.1":
+  version "1.44.1"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.44.1.tgz#cc874ec31342479ad99838040e99b5f604299bcb"
+  integrity sha512-1hZ4TNvD5z9VuhNJ/walIjvMVvYkZKf71axoF/uiAqpntQJXpG64dlXhoDXE3OczPuTuvjf/M5KWFg5VAVUS3Q==
+  dependencies:
+    playwright "1.44.1"
+
 "@rollup/plugin-json@^6.0.1":
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-json/-/plugin-json-6.1.0.tgz#fbe784e29682e9bb6dee28ea75a1a83702e7b805"
@@ -5320,6 +5327,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
+fsevents@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+
 fsevents@~2.3.2, fsevents@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
@@ -7706,6 +7718,20 @@ pkg-types@^1.0.3:
     jsonc-parser "^3.2.0"
     mlly "^1.2.0"
     pathe "^1.1.0"
+
+playwright-core@1.44.1:
+  version "1.44.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.44.1.tgz#53ec975503b763af6fc1a7aa995f34bc09ff447c"
+  integrity sha512-wh0JWtYTrhv1+OSsLPgFzGzt67Y7BE/ZS3jEqgGBlp2ppp1ZDj8c+9IARNW4dwf1poq5MgHreEM2KV/GuR4cFA==
+
+playwright@1.44.1, playwright@^1.44.1:
+  version "1.44.1"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.44.1.tgz#5634369d777111c1eea9180430b7a184028e7892"
+  integrity sha512-qr/0UJ5CFAtloI3avF95Y0L1xQo6r3LQArLIg/z/PoGJ6xa+EwzrwO5lpNr/09STxdHuUoP2mvuELJS+hLdtgg==
+  dependencies:
+    playwright-core "1.44.1"
+  optionalDependencies:
+    fsevents "2.3.2"
 
 possible-typed-array-names@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## What is this PR and why do we need it?

This PR aims to enhance the test coverage within the SDKs by adding tests for cookie behaviors across various authentication states. The tests cover scenarios for unauthenticated users, authenticated users, and post-logout behaviors, ensuring that cookies are correctly set and removed based on the authentication state.

**Changes Made**

- Added Playwright 
- Added new end-to-end tests to cover cookie behaviors for unauthenticated, authenticated, and post-logout states.
- Ensured that cookies are correctly set and removed based on the authentication state.

**Testing**
To test these changes:

1. Link the SDK being tested with the corresponding quickstart application.
2. Run the web server of the quickstart application with the FA server.
3.  In a separate instance of your CL, execute yarn test:e2e to run the end-to-end tests.

These tests will need to be verified on Vue, Angular, and React, and all tests should pass successfully on each framework.

https://github.com/FusionAuth/fusionauth-javascript-sdk/issues/111

#### Pre-Merge Checklist (if applicable)

- [x] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.
