### PR TITLE
111 Add Endpoints E2E Tests Phase 1

### DIFF
--- a/e2e/pages/common.page.ts
+++ b/e2e/pages/common.page.ts
@@ -7,7 +7,7 @@ const Locators = {
   submitBtn: 'role=button[name="Submit"]',
   createAccountBtn: 'role=button[name="create a new account"]',
   registerBtn: 'role=button[name="Register"]',
-  logOutBtn: 'role=button[name="Logout"]',
+  logOutBtn: 'text=Logout',
 } as const;
 
 type LocatorsKey = keyof typeof Locators;

--- a/e2e/tests/endpoints.test.ts
+++ b/e2e/tests/endpoints.test.ts
@@ -1,0 +1,112 @@
+import { Page, test, BrowserContext, expect } from '@playwright/test';
+import { quickstartPage } from './common.page';
+
+test.describe('Endpoint Tests', () => {
+  let page: Page;
+  let quickstart: quickstartPage;
+  let browserContext: BrowserContext;
+
+  test.beforeAll(async ({ browser }) => {
+    browserContext = await browser.newContext();
+    page = await browserContext.newPage();
+    quickstart = new quickstartPage(page);
+    await page.goto('/');
+    await quickstart.navToLogIn();
+    await quickstart.authenticate();
+  });
+
+  test('GET /app/me', async () => {
+    const cookies = await browserContext.cookies();
+    const appAtCookie = cookies.find(cookie => cookie.name === 'app.at');
+
+    const response = await browserContext.request.get(
+      'http://localhost:9011/app/me',
+      {
+        headers: {
+          Authorization: `Bearer ${appAtCookie?.value}`,
+          Origin: 'http://localhost:3000',
+          Referer: 'http://localhost:3000/',
+        },
+      },
+    );
+
+    expect(response.headers()['content-type']).toContain('application/json');
+    expect(response.ok()).toBeTruthy();
+  });
+
+  test('GET /app/logout', async () => {
+    const cookieNames = ['app.at', 'app.idt', 'app.rt', 'app.at_exp'];
+    const cookiesBeforeLogout = await browserContext.cookies();
+
+    cookieNames.forEach(cookieName => {
+      const cookie = cookiesBeforeLogout.find(
+        cookie => cookie.name === cookieName,
+      );
+      expect(cookie).toBeDefined();
+    });
+
+    let is302 = false;
+
+    await page.route('**/app/logout', route => route.continue());
+
+    page.on('response', response => {
+      if (response.url().includes('/app/logout') && response.status() === 302) {
+        is302 = true;
+        expect(response.headers()?.location).toContain('oauth2/logout?');
+      }
+    });
+
+    await quickstart.logOut();
+    expect(is302).toBe(true);
+
+    const cookiesAfterLogout = await browserContext.cookies();
+    cookieNames.forEach(cookieName => {
+      const cookie = cookiesAfterLogout.find(
+        cookie => cookie.name === cookieName,
+      );
+      expect(cookie).toBeUndefined();
+    });
+  });
+
+  test('GET /app/login', async () => {
+    await quickstart.logOut();
+
+    let is302 = false;
+    let codeChallengePassed = false;
+    let redirectUrlEncoded: string | null = null;
+
+    await page.route('**/app/login', route => route.continue());
+
+    page.on('response', async response => {
+      if (response.url().includes('/app/login') && response.status() === 302) {
+        is302 = true;
+        const locationHeader = response.headers()?.location;
+        if (locationHeader) {
+          expect(locationHeader).toContain('oauth2/authorize?');
+          const queryParameters = new URLSearchParams(
+            locationHeader.split('?')[1],
+          );
+          const codeChallenge = queryParameters.get('code_challenge');
+          const codeChallengeMethod = queryParameters.get(
+            'code_challenge_method',
+          );
+          expect(codeChallenge).toBeDefined();
+          expect(codeChallengeMethod).toBe('S256');
+          codeChallengePassed = true;
+          redirectUrlEncoded = queryParameters.get('redirect_uri');
+        }
+      }
+    });
+
+    await quickstart.navToLogIn();
+
+    expect(is302).toBe(true);
+    expect(codeChallengePassed).toBe(true);
+    expect(redirectUrlEncoded).not.toBeNull();
+    expect(redirectUrlEncoded!).toContain('/app/callback');
+
+    const cookies = await browserContext.cookies();
+    const pkceCookie = cookies.find(cookie => cookie.name === 'app.pkce_v');
+    expect(pkceCookie).toBeDefined();
+  });
+});

--- a/e2e/tests/endpoints.test.ts
+++ b/e2e/tests/endpoints.test.ts
@@ -24,8 +24,8 @@ test.describe('Endpoint Tests', () => {
       {
         headers: {
           Authorization: `Bearer ${appAtCookie?.value}`,
-          Origin: 'http://localhost:3000',
-          Referer: 'http://localhost:3000/',
+          Origin: `http://localhost:${process.env.PORT}`,
+          Referer: `http://localhost:${process.env.PORT}/`,
         },
       },
     );

--- a/e2e/tests/endpoints.test.ts
+++ b/e2e/tests/endpoints.test.ts
@@ -1,5 +1,5 @@
 import { Page, test, BrowserContext, expect } from '@playwright/test';
-import { quickstartPage } from './common.page';
+import { quickstartPage } from '../pages/common.page';
 
 test.describe('Endpoint Tests', () => {
   let page: Page;

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,14 +1,5 @@
 import { defineConfig, devices } from '@playwright/test';
 
-/**
- * Read environment variables from file.
- * https://github.com/motdotla/dotenv
- */
-// require('dotenv').config();
-
-/**
- * See https://playwright.dev/docs/test-configuration.
- */
 export default defineConfig({
   testDir: './e2e',
   /* Run tests in files in parallel */
@@ -22,7 +13,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: 'http://localhost:3000',
+    baseURL: `http://localhost:${process.env.PORT}`,
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     screenshot: 'on',
@@ -48,8 +39,8 @@ export default defineConfig({
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: 'npm run dev',
-    url: 'http://localhost:3000',
+    command: `${process.env.SERVER_COMMAND}`,
+    url: `http://localhost:${process.env.PORT}`,
     reuseExistingServer: !process.env.CI,
   },
 });


### PR DESCRIPTION
### What is this PR and why do we need it?
This PR aims to enhance the test coverage within the SDKs by adding tests to check endpoint behaviors across various authentication states. The tests cover scenarios for unauthenticated users, authenticated users, and post-logout behaviors, ensuring that cookies are correctly set and removed, endpoints are performing their required interactions with the FA API based on simulated real user interactions with the UI.

**Changes Made**

**Added tests for `GET /app/me`**

- Verifies the presence of the `app.at` cookie.
- Sends a request to `/app/me` endpoint with the authentication token.
- Asserts that the response content type is `application/json` and the response is successful.

**Added tests for `GET /app/logout`**

- Checks for the presence of required cookies before logout.
- Routes the `/app/logout` endpoint and ensures a `302` status redirect to `/oauth2/logout`.
- Verifies that the cookies are cleared post-logout.

**Added tests for `GET /app/login`**

- Logs out before starting the test.
- Routes the `/app/login` endpoint and ensures a `302` status redirect to `/oauth2/authorize`.
- Verifies that the PKCE code challenge is passed along correctly and set.
- Confirms that the `redirect_uri` is encoded and saved to the state, redirecting to `/app/callback`.


**Testing**
To test these changes:

1. Link the SDK being tested with the corresponding quickstart application.
2. Run the web server of the quickstart application with the FA server.
3. In a separate instance of your CLI, execute `SERVER_COMMAND='' PORT= yarn test:e2e` to run the end-to-end tests.
4. These tests will need to be verified on Vue, Angular, and React, and all tests should pass successfully on each framework.

https://github.com/FusionAuth/fusionauth-javascript-sdk/issues/111

Pre-Merge Checklist (if applicable)
 [x] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.
