### PR TITLE
122 Add E2E Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 - [Development](#development)
     - [Gotchas](#gotchas)
 - [Manual testing](#manual-testing)
+- [Automated testing](#automated-testing)
 - [Architecture](#architecture)
 - [Release Process](#release-process)
 - [Upgrade Policy](#upgrade-policy)
@@ -60,6 +61,44 @@ The SDKs provide the following functionality:
 - Failure to fetch user info provides a helpful error to the consuming application
 - Access token can be automatically and continuously refreshed
 - Redirect callback is invoked after login or register
+
+## Automated testing
+The Playwright end-to-end tests verify the proper functionality of several authentication and authorization endpoints in the FA SDK.
+
+Prerequisites
+- Ensure Playwright has been installed as a dependency 
+- On a seperate server run the FA SDK consuming quickstart application.
+
+Configuration
+The Playwright configuration (playwright.config.ts) includes settings for running tests in parallel, specifying browser environments, and defining the base URL the tests will perform on.
+
+Running the Tests
+Prior to running the tests you will want to check the Server Command that is used to start up a local instance of the FA SDK consuming quickstart application. Additionally you will want to note the port number this application will run on.
+
+Run Tests:
+`SERVER_COMMAND="your-server-start-command" PORT=your-port-number yarn test:e2e`
+    Example: `SERVER_COMMAND="npm run start" PORT=9011 yarn test:e2e`
+
+The tests cover the following endpoints and functionalities:
+
+-Baseline Authentication: Verifies the login and registration navigation and logout functionality.
+-GET /app/me: Checks if the authenticated user’s information is correctly retrieved.
+-GET /app/logout: Ensures that logging out invalidates the session cookies.
+-GET /app/login: Validates the login process, ensuring proper PKCE (Proof Key for Code Exchange) implementation.
+-GET /app/register: Checks the registration process, ensuring proper PKCE implementation.
+-POST /app/refresh/{clientId}: Validates the token refresh functionality.
+
+Maintenance
+
+Page Object Model (POM):
+The Page Object Model (POM) is a design pattern in test automation that creates an object repository for web UI elements found in the pages directory. This makes tests more maintainable and reusable. 
+    Example: In common.page.ts, methods for navigation and authentication are defined.
+Tests import these page objects to perform actions, ensuring that if the UI changes, only the page object needs updating, not all the tests.
+
+Updating Tests:
+Modify existing tests or add new tests in the e2e tests directory as needed.
+When the UI changes, update the corresponding methods in the page objects.
+
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 - [Development](#development)
     - [Gotchas](#gotchas)
 - [Manual testing](#manual-testing)
-- [Automated testing](#automated-testing)
+- [E2E testing](#e2e-testing)
 - [Architecture](#architecture)
 - [Release Process](#release-process)
 - [Upgrade Policy](#upgrade-policy)
@@ -62,7 +62,7 @@ The SDKs provide the following functionality:
 - Access token can be automatically and continuously refreshed
 - Redirect callback is invoked after login or register
 
-## Automated testing
+## E2E testing
 The [Playwright](https://playwright.dev/docs/intro) end-to-end tests verify the proper functionality of several authentication and authorization endpoints in the FA SDK.
 
 Prerequisites
@@ -73,20 +73,12 @@ Configuration
 The Playwright configuration (playwright.config.ts) includes settings for running tests in parallel, specifying browser environments, and defining the base URL the tests will perform on.
 
 Running the Tests
+
 Prior to running the tests you will want to check the Server Command that is used to start up a local instance of the FA SDK consuming quickstart application. Additionally you will want to note the port number this application will run on.
 
 Run Tests:
 `SERVER_COMMAND="your-server-start-command" PORT=your-port-number yarn test:e2e`
     Example: `SERVER_COMMAND="npm run start" PORT=9011 yarn test:e2e`
-
-The tests cover the following endpoints and functionalities:
-
-- Baseline Authentication: Verifies the login and registration navigation and logout functionality.
-- GET /app/me: Checks if the authenticated user’s information is correctly retrieved.
-- GET /app/logout: Ensures that logging out invalidates the session cookies.
-- GET /app/login: Validates the login process, ensuring proper PKCE (Proof Key for Code Exchange) implementation.
-- GET /app/register: Checks the registration process, ensuring proper PKCE implementation.
-- POST /app/refresh/{clientId}: Validates the token refresh functionality.
 
 Structure
 The e2e tests are structured to use the Page Object Model (POM) design pattern. A POM is a design pattern in test automation that creates an object repository for web UI elements found in the pages directory. This makes tests more maintainable and reusable. 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Prerequisites
 - On a seperate server run the FA SDK consuming quickstart application.
 
 Configuration
+
 The Playwright configuration (playwright.config.ts) includes settings for running tests in parallel, specifying browser environments, and defining the base URL the tests will perform on.
 
 Running the Tests
@@ -77,14 +78,15 @@ Running the Tests
 Prior to running the tests you will want to check the Server Command that is used to start up a local instance of the FA SDK consuming quickstart application. Additionally you will want to note the port number this application will run on.
 
 Run Tests:
+
 `SERVER_COMMAND="your-server-start-command" PORT=your-port-number yarn test:e2e`
     Example: `SERVER_COMMAND="npm run start" PORT=9011 yarn test:e2e`
 
 Structure
+
 The e2e tests are structured to use the Page Object Model (POM) design pattern. A POM is a design pattern in test automation that creates an object repository for web UI elements found in the pages directory. This makes tests more maintainable and reusable. 
     Example: In common.page.ts, methods for navigation and authentication are defined.
 Tests import these page objects to perform actions, ensuring that if the UI changes, only the page object needs updating, not all the tests.
-
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The SDKs provide the following functionality:
 - Redirect callback is invoked after login or register
 
 ## Automated testing
-The Playwright end-to-end tests verify the proper functionality of several authentication and authorization endpoints in the FA SDK.
+The [Playwright](https://playwright.dev/docs/intro) end-to-end tests verify the proper functionality of several authentication and authorization endpoints in the FA SDK.
 
 Prerequisites
 - Ensure Playwright has been installed as a dependency 
@@ -81,12 +81,12 @@ Run Tests:
 
 The tests cover the following endpoints and functionalities:
 
--Baseline Authentication: Verifies the login and registration navigation and logout functionality.
--GET /app/me: Checks if the authenticated user’s information is correctly retrieved.
--GET /app/logout: Ensures that logging out invalidates the session cookies.
--GET /app/login: Validates the login process, ensuring proper PKCE (Proof Key for Code Exchange) implementation.
--GET /app/register: Checks the registration process, ensuring proper PKCE implementation.
--POST /app/refresh/{clientId}: Validates the token refresh functionality.
+- Baseline Authentication: Verifies the login and registration navigation and logout functionality.
+- GET /app/me: Checks if the authenticated user’s information is correctly retrieved.
+- GET /app/logout: Ensures that logging out invalidates the session cookies.
+- GET /app/login: Validates the login process, ensuring proper PKCE (Proof Key for Code Exchange) implementation.
+- GET /app/register: Checks the registration process, ensuring proper PKCE implementation.
+- POST /app/refresh/{clientId}: Validates the token refresh functionality.
 
 Maintenance
 

--- a/README.md
+++ b/README.md
@@ -88,16 +88,10 @@ The tests cover the following endpoints and functionalities:
 - GET /app/register: Checks the registration process, ensuring proper PKCE implementation.
 - POST /app/refresh/{clientId}: Validates the token refresh functionality.
 
-Maintenance
-
-Page Object Model (POM):
-The Page Object Model (POM) is a design pattern in test automation that creates an object repository for web UI elements found in the pages directory. This makes tests more maintainable and reusable. 
+Structure
+The e2e tests are structured to use the Page Object Model (POM) design pattern. A POM is a design pattern in test automation that creates an object repository for web UI elements found in the pages directory. This makes tests more maintainable and reusable. 
     Example: In common.page.ts, methods for navigation and authentication are defined.
 Tests import these page objects to perform actions, ensuring that if the UI changes, only the page object needs updating, not all the tests.
-
-Updating Tests:
-Modify existing tests or add new tests in the e2e tests directory as needed.
-When the UI changes, update the corresponding methods in the page objects.
 
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -77,10 +77,11 @@ Running the Tests
 
 Prior to running the tests you will want to check the Server Command that is used to start up a local instance of the FA SDK consuming quickstart application. Additionally you will want to note the port number this application will run on.
 
-Run Tests:
+To run the tests, enter the following command with the FA SDK consuming quickstart application server start command and port number:
 
 `SERVER_COMMAND="your-server-start-command" PORT=your-port-number yarn test:e2e`
-    Example: `SERVER_COMMAND="npm run start" PORT=9011 yarn test:e2e`
+
+Example: `SERVER_COMMAND="npm run start" PORT=9011 yarn test:e2e`
 
 Structure
 


### PR DESCRIPTION
## What is this PR and why do we need it?

This PR adds documentation on how to run the existing end-to-end tests for the FA SDK using Playwright. The documentation includes instructions for setting up the environment, running the tests, and maintaining the tests. It ensures that developers can easily execute the tests and understand the underlying configurations and dependencies.

#### Pre-Merge Checklist (if applicable)

- [x] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.
