### PR TITLE
Add Account Management function/button

### DIFF
--- a/packages/core/src/SDKCore/SDKCore.ts
+++ b/packages/core/src/SDKCore/SDKCore.ts
@@ -42,6 +42,10 @@ export class SDKCore {
     window.location.assign(this.urlHelper.getLogoutUrl());
   }
 
+  manageAccount() {
+    window.location.assign(this.urlHelper.getAccountManagementUrl());
+  }
+
   async fetchUserInfo() {
     const userInfoResponse = await fetch(this.urlHelper.getMeUrl(), {
       credentials: 'include',
@@ -122,7 +126,11 @@ export class SDKCore {
     );
   }
 
-  /** Schedules `onTokenExpiration` at moment of access token expiration. */
+  /**
+   * Schedules `onTokenExpiration` at moment of access token expiration.
+   * SDKCore is not necessarily reactive like React, Angular, and Vue.
+   * so `onTokenExpiration` is for reactive frameworks to hook in and perform actions as on token expiration.
+   */
   private scheduleTokenExpiration(): void {
     clearTimeout(this.tokenExpirationTimeout);
 

--- a/packages/core/src/UrlHelper/UrlHelper.test.ts
+++ b/packages/core/src/UrlHelper/UrlHelper.test.ts
@@ -16,7 +16,7 @@ describe('UrlHelper', () => {
   it('me url', () => {
     const meUrl = urlHelper.getMeUrl();
     expect(meUrl.origin).toBe(config.serverUrl);
-    expect(meUrl.pathname).toBe('/app/me');
+    expect(meUrl.pathname).toBe('/app/me/');
     expect(meUrl.search).toBe('');
   });
 
@@ -24,7 +24,7 @@ describe('UrlHelper', () => {
     const stateValue = 'login-state-value';
     const loginUrl = urlHelper.getLoginUrl(stateValue);
     expect(loginUrl.origin).toBe(config.serverUrl);
-    expect(loginUrl.pathname).toBe('/app/login');
+    expect(loginUrl.pathname).toBe('/app/login/');
     expect(loginUrl.searchParams.get('client_id')).toBe(config.clientId);
     expect(loginUrl.searchParams.get('redirect_uri')).toBe(config.redirectUri);
     expect(loginUrl.searchParams.get('scope')).toBe(config.scope);
@@ -35,7 +35,7 @@ describe('UrlHelper', () => {
     const stateValue = 'register-state-value';
     const registerUrl = urlHelper.getRegisterUrl(stateValue);
     expect(registerUrl.origin).toBe(config.serverUrl);
-    expect(registerUrl.pathname).toBe('/app/register');
+    expect(registerUrl.pathname).toBe('/app/register/');
     expect(registerUrl.searchParams.get('client_id')).toBe(config.clientId);
     expect(registerUrl.searchParams.get('redirect_uri')).toBe(
       config.redirectUri,
@@ -47,7 +47,7 @@ describe('UrlHelper', () => {
   it('logout url', () => {
     const logoutUrl = urlHelper.getLogoutUrl();
     expect(logoutUrl.origin).toBe(config.serverUrl);
-    expect(logoutUrl.pathname).toBe('/app/logout');
+    expect(logoutUrl.pathname).toBe('/app/logout/');
     expect(logoutUrl.searchParams.get('client_id')).toBe(config.clientId);
     expect(logoutUrl.searchParams.get('post_logout_redirect_uri')).toBe(
       config.postLogoutRedirectUri,
@@ -67,7 +67,7 @@ describe('UrlHelper', () => {
     );
     const logoutUrl = urlHelperWithoutPostLogoutRedirectUri.getLogoutUrl();
     expect(logoutUrl.origin).toBe(configWithoutPostLogoutRedirectUri.serverUrl);
-    expect(logoutUrl.pathname).toBe('/app/logout');
+    expect(logoutUrl.pathname).toBe('/app/logout/');
     expect(logoutUrl.searchParams.get('client_id')).toBe(
       configWithoutPostLogoutRedirectUri.clientId,
     );
@@ -78,8 +78,16 @@ describe('UrlHelper', () => {
 
   it('tokenRefresh url', () => {
     const tokenRefreshUrl = urlHelper.getTokenRefreshUrl();
-    expect(tokenRefreshUrl.pathname).toBe('/app/refresh');
+    expect(tokenRefreshUrl.pathname).toBe('/app/refresh/');
     expect(tokenRefreshUrl.searchParams.get('client_id')).toBe(config.clientId);
+  });
+
+  it('account management url', () => {
+    const accountManagementUrl = urlHelper.getAccountManagementUrl();
+    expect(accountManagementUrl.pathname).toBe('/account/');
+    expect(accountManagementUrl.searchParams.get('client_id')).toBe(
+      config.clientId,
+    );
   });
 
   it('Should generate urls with a specified path', () => {

--- a/packages/core/src/UrlHelper/UrlHelper.ts
+++ b/packages/core/src/UrlHelper/UrlHelper.ts
@@ -21,11 +21,11 @@ export class UrlHelper {
     this.scope = config.scope;
     this.postLogoutRedirectUri = config.postLogoutRedirectUri;
 
-    this.mePath = config.mePath ?? '/app/me';
-    this.loginPath = config.loginPath ?? '/app/login';
-    this.registerPath = config.registerPath ?? '/app/register';
-    this.logoutPath = config.logoutPath ?? '/app/logout';
-    this.tokenRefreshPath = config.tokenRefreshPath ?? '/app/refresh';
+    this.mePath = config.mePath ?? '/app/me/';
+    this.loginPath = config.loginPath ?? '/app/login/';
+    this.registerPath = config.registerPath ?? '/app/register/';
+    this.logoutPath = config.logoutPath ?? '/app/logout/';
+    this.tokenRefreshPath = config.tokenRefreshPath ?? '/app/refresh/';
   }
 
   getMeUrl(): URL {
@@ -59,6 +59,12 @@ export class UrlHelper {
 
   getTokenRefreshUrl(): URL {
     return this.generateUrl(this.tokenRefreshPath, {
+      client_id: this.clientId,
+    });
+  }
+
+  getAccountManagementUrl(): URL {
+    return this.generateUrl('/account/', {
       client_id: this.clientId,
     });
   }

--- a/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/components/fusionauth-account.button/fusion-auth-account-button.component.html
+++ b/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/components/fusionauth-account.button/fusion-auth-account-button.component.html
@@ -1,0 +1,3 @@
+<button class="fa-button" (click)="manageAccount()">
+  <span>manage account</span>
+</button>

--- a/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/components/fusionauth-account.button/fusion-auth-account-button.component.scss
+++ b/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/components/fusionauth-account.button/fusion-auth-account-button.component.scss
@@ -1,0 +1,15 @@
+.fa-button {
+  padding: 16px 16px 13px 16px;
+  border-radius: 8px;
+  background-color: #083b94;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica,
+    Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+  font-size: 18px;
+  font-weight: 600;
+  text-align: center;
+  color: #fff;
+  &:hover {
+    cursor: pointer;
+  }
+  width: 400px;
+}

--- a/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/components/fusionauth-account.button/fusion-auth-account-button.component.spec.ts
+++ b/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/components/fusionauth-account.button/fusion-auth-account-button.component.spec.ts
@@ -1,0 +1,29 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { FusionAuthAccountButtonComponent } from './fusion-auth-account-button.component';
+import { FusionAuthService } from '../../fusion-auth.service';
+
+describe('FusionauthAccountButtonComponent', () => {
+  let component: FusionAuthAccountButtonComponent;
+  let fixture: ComponentFixture<FusionAuthAccountButtonComponent>;
+  const mockService = jasmine.createSpyObj('FusionAuthService', [
+    'manageAccount',
+  ]);
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [FusionAuthAccountButtonComponent],
+      providers: [{ provide: FusionAuthService, useValue: mockService }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(FusionAuthAccountButtonComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should invoke the `manageAccount` method', () => {
+    expect(component).toBeTruthy();
+    component.manageAccount();
+    expect(mockService.manageAccount).toHaveBeenCalled();
+  });
+});

--- a/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/components/fusionauth-account.button/fusion-auth-account-button.component.ts
+++ b/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/components/fusionauth-account.button/fusion-auth-account-button.component.ts
@@ -1,0 +1,15 @@
+import { Component } from '@angular/core';
+import { FusionAuthService } from '../../fusion-auth.service';
+
+@Component({
+  selector: 'fa-account',
+  templateUrl: './fusion-auth-account-button.component.html',
+  styleUrls: ['./fusion-auth-account-button.component.scss'],
+})
+export class FusionAuthAccountButtonComponent {
+  constructor(private fusionAuth: FusionAuthService) {}
+
+  manageAccount() {
+    this.fusionAuth.manageAccount();
+  }
+}

--- a/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.module.ts
+++ b/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.module.ts
@@ -5,18 +5,21 @@ import { FUSIONAUTH_SERVICE_CONFIG } from './injectionToken';
 import { FusionAuthLoginButtonComponent } from './components/fusionauth-login.button/fusion-auth-login-button.component';
 import { FusionAuthLogoutButtonComponent } from './components/fusionauth-logout.button/fusion-auth-logout-button.component';
 import { FusionAuthRegisterButtonComponent } from './components/fusionauth-register.button/fusion-auth-register-button.component';
+import { FusionAuthAccountButtonComponent } from './components/fusionauth-account.button/fusion-auth-account-button.component';
 
 @NgModule({
   declarations: [
     FusionAuthLoginButtonComponent,
     FusionAuthLogoutButtonComponent,
     FusionAuthRegisterButtonComponent,
+    FusionAuthAccountButtonComponent,
   ],
   imports: [],
   exports: [
     FusionAuthLoginButtonComponent,
     FusionAuthLogoutButtonComponent,
     FusionAuthRegisterButtonComponent,
+    FusionAuthAccountButtonComponent,
   ],
 })
 export class FusionAuthModule {

--- a/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.ts
+++ b/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.ts
@@ -125,4 +125,12 @@ export class FusionAuthService {
   logout(): void {
     this.core.startLogout();
   }
+
+  /**
+   * Redirects to [self service account management](https://fusionauth.io/docs/lifecycle/manage-users/account-management/)
+   * Self service account management is only available in FusionAuth paid plans.
+   */
+  manageAccount(): void {
+    this.core.manageAccount();
+  }
 }

--- a/packages/sdk-angular/projects/fusionauth-angular-sdk/src/public-api.ts
+++ b/packages/sdk-angular/projects/fusionauth-angular-sdk/src/public-api.ts
@@ -6,5 +6,6 @@ export * from './lib/fusion-auth.service';
 export * from './lib/components/fusionauth-login.button/fusion-auth-login-button.component';
 export * from './lib/components/fusionauth-logout.button/fusion-auth-logout-button.component';
 export * from './lib/components/fusionauth-register.button/fusion-auth-register-button.component';
+export * from './lib/components/fusionauth-account.button/fusion-auth-account-button.component';
 export * from './lib/fusion-auth.module';
 export * from './lib/types';

--- a/packages/sdk-react/src/components/providers/FusionAuthProvider.test.tsx
+++ b/packages/sdk-react/src/components/providers/FusionAuthProvider.test.tsx
@@ -1,5 +1,5 @@
-import { PropsWithChildren } from 'react';
-import { act, waitFor, renderHook } from '@testing-library/react';
+import { PropsWithChildren, act } from 'react';
+import { waitFor, renderHook } from '@testing-library/react';
 import { describe, afterEach, test, expect, vi } from 'vitest';
 
 import {
@@ -40,7 +40,7 @@ describe('FusionAuthProvider', () => {
     result.current.startLogin(stateValue);
 
     const expectedUrl = new URL(TEST_CONFIG.serverUrl);
-    expectedUrl.pathname = '/app/login';
+    expectedUrl.pathname = '/app/login/';
     expectedUrl.searchParams.set('client_id', TEST_CONFIG.clientId);
     expectedUrl.searchParams.set('redirect_uri', TEST_CONFIG.redirectUri);
     expectedUrl.searchParams.set('scope', TEST_CONFIG.scope!);
@@ -57,7 +57,7 @@ describe('FusionAuthProvider', () => {
     result.current.startLogout();
 
     const expectedUrl = new URL(TEST_CONFIG.serverUrl);
-    expectedUrl.pathname = '/app/logout';
+    expectedUrl.pathname = '/app/logout/';
     expectedUrl.searchParams.set('client_id', TEST_CONFIG.clientId);
     expectedUrl.searchParams.set(
       'post_logout_redirect_uri',
@@ -76,7 +76,7 @@ describe('FusionAuthProvider', () => {
     result.current.startRegister(stateValue);
 
     const expectedUrl = new URL(TEST_CONFIG.serverUrl);
-    expectedUrl.pathname = '/app/register';
+    expectedUrl.pathname = '/app/register/';
     expectedUrl.searchParams.set('client_id', TEST_CONFIG.clientId);
     expectedUrl.searchParams.set('redirect_uri', TEST_CONFIG.redirectUri);
     expectedUrl.searchParams.set(
@@ -152,7 +152,7 @@ describe('FusionAuthProvider', () => {
 
     await waitFor(() => {
       expect(fetch).toHaveBeenCalledWith(
-        new URL('http://localhost:9000/app/me'),
+        new URL('http://localhost:9000/app/me/'),
         {
           credentials: 'include',
         },
@@ -216,7 +216,7 @@ describe('FusionAuthProvider', () => {
     expect(fetch).toHaveBeenCalledTimes(1); // called
 
     const expectedUrl = new URL(TEST_CONFIG.serverUrl);
-    expectedUrl.pathname = '/app/refresh';
+    expectedUrl.pathname = '/app/refresh/';
     expectedUrl.searchParams.set('client_id', TEST_CONFIG.clientId);
     expect(fetch).toHaveBeenCalledWith(expectedUrl, {
       method: 'POST',

--- a/packages/sdk-vue/src/createFusionAuth/createFusionAuth.test.ts
+++ b/packages/sdk-vue/src/createFusionAuth/createFusionAuth.test.ts
@@ -135,7 +135,7 @@ describe('createFusionAuth', () => {
     fusionAuth.login(stateValue);
 
     const expectedUrl = new URL(config.serverUrl);
-    expectedUrl.pathname = '/app/login';
+    expectedUrl.pathname = '/app/login/';
     expectedUrl.searchParams.set('client_id', config.clientId);
     expectedUrl.searchParams.set('redirect_uri', config.redirectUri);
     expectedUrl.searchParams.set('scope', config.scope!);
@@ -152,7 +152,7 @@ describe('createFusionAuth', () => {
     fusionAuth.register(stateValue);
 
     const expectedUrl = new URL(config.serverUrl);
-    expectedUrl.pathname = '/app/register';
+    expectedUrl.pathname = '/app/register/';
     expectedUrl.searchParams.set('client_id', config.clientId);
     expectedUrl.searchParams.set('redirect_uri', config.redirectUri);
     expectedUrl.searchParams.set('scope', config.scope!);
@@ -168,7 +168,7 @@ describe('createFusionAuth', () => {
     fusionAuth.logout();
 
     const expectedUrl = new URL(config.serverUrl);
-    expectedUrl.pathname = '/app/logout';
+    expectedUrl.pathname = '/app/logout/';
     expectedUrl.searchParams.set('client_id', config.clientId);
     expectedUrl.searchParams.set(
       'post_logout_redirect_uri',


### PR DESCRIPTION
## Add Account Management function/button
#32 Adding `manageAccount` to SDKCore, and then #127 Angular.

It should redirect to the [hosted account management app](https://fusionauth.io/docs/lifecycle/manage-users/account-management/). Self service account management is a paid feature of fusionauth -- mentioned in the JSDoc comment for the public-facing method.

**Changes**
- Add `manageAccount` function to `SDKCore`
- Add trailing slashes to URL default pathnames. I found that the account URL doesn’t work without a trailing slash on the pathname. It seems like adding a trailing slash to URL pathnames is generally safer because it separates the pathname and query string. (Had to update corresponding react and vue tests)
- Add `manageAccount` method to fusionauth service in Angular SDK.
- Add `FusionAuthAccountButtonComponent` to Angular SDK

#### Pre-Merge Checklist (if applicable)
- [x] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.
