### PR TITLE
[Vue] Account Management function/button

### DIFF
--- a/packages/sdk-vue/src/components/FusionAuthAccountButton/FusionAuthAccountButton.vue
+++ b/packages/sdk-vue/src/components/FusionAuthAccountButton/FusionAuthAccountButton.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+import { useFusionAuth } from '#/composables/useFusionAuth.ts';
+const { manageAccount } = useFusionAuth();
+</script>
+
+<template>
+  <button class="fusionauth-button" @click="manageAccount()">
+    <slot>Manage Account</slot>
+  </button>
+</template>
+
+<style lang="scss" scoped>
+@import '#/styles/button.scss';
+</style>

--- a/packages/sdk-vue/src/components/index.ts
+++ b/packages/sdk-vue/src/components/index.ts
@@ -1,6 +1,7 @@
 import FusionAuthLoginButton from './FusionAuthLoginButton/FusionAuthLoginButton.vue';
 import FusionAuthLogoutButton from './FusionAuthLogoutButton/FusionAuthLogoutButton.vue';
 import FusionAuthRegisterButton from './FusionAuthRegisterButton/FusionAuthRegisterButton.vue';
+import FusionAuthAccountButton from './FusionAuthAccountButton/FusionAuthAccountButton.vue';
 import RequireAuth from './RequireAuth/RequireAuth.vue';
 import RequireAnonymous from './RequireAnonymous/RequireAnonymous.vue';
 
@@ -8,6 +9,7 @@ export {
   FusionAuthLoginButton,
   FusionAuthLogoutButton,
   FusionAuthRegisterButton,
+  FusionAuthAccountButton,
   RequireAuth,
   RequireAnonymous,
 };

--- a/packages/sdk-vue/src/createFusionAuth/createFusionAuth.ts
+++ b/packages/sdk-vue/src/createFusionAuth/createFusionAuth.ts
@@ -57,6 +57,10 @@ export const createFusionAuth = (config: FusionAuthConfig): FusionAuth => {
     core.startLogout();
   }
 
+  function manageAccount() {
+    core.manageAccount();
+  }
+
   if (config.shouldAutoFetchUserInfo && core.isLoggedIn === true) {
     getUserInfo();
   }
@@ -76,6 +80,7 @@ export const createFusionAuth = (config: FusionAuthConfig): FusionAuth => {
     login,
     register,
     logout,
+    manageAccount,
     refreshToken,
     initAutoRefresh,
   };

--- a/packages/sdk-vue/src/types.ts
+++ b/packages/sdk-vue/src/types.ts
@@ -151,6 +151,12 @@ export interface FusionAuth {
   logout: () => void;
 
   /**
+   * Redirects to [self service account management](https://fusionauth.io/docs/lifecycle/manage-users/account-management/)
+   * Self service account management is only available in FusionAuth paid plans.
+   */
+  manageAccount: () => void;
+
+  /**
    * Refreshes the access token a single time.
    * Token refreshing is handled automatically if configured with `shouldAutoRefresh`.
    */

--- a/packages/sdk-vue/web-types.json
+++ b/packages/sdk-vue/web-types.json
@@ -8,6 +8,19 @@
       "types-syntax": "typescript",
       "tags": [
         {
+          "name": "FusionAuthAccountButton",
+          "description": "",
+          "slots": [
+            {
+              "name": "default"
+            }
+          ],
+          "source": {
+            "module": "./src/components/FusionAuthAccountButton/FusionAuthAccountButton.vue",
+            "symbol": "default"
+          }
+        },
+        {
           "name": "FusionAuthLoginButton",
           "description": "",
           "attributes": [


### PR DESCRIPTION
## Account Management function/button
Completing issue #32 for the Vue SDK (#128).
Adding account management function and button for Vue SDK.

The button component is registered as `FusionAuthAccountButton`

#### Pre-Merge Checklist (if applicable)
- [x] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.
