### PR TITLE
[React] Account Management Functionality and Button

### DIFF
--- a/packages/sdk-react/src/components/providers/Context.tsx
+++ b/packages/sdk-react/src/components/providers/Context.tsx
@@ -5,6 +5,7 @@ export const defaultContext: FusionAuthProviderContext = {
   startLogin: () => {},
   startLogout: () => {},
   startRegister: () => {},
+  manageAccount: () => {},
   userInfo: null,
   fetchUserInfo: () => Promise.resolve({}),
   isFetchingUserInfo: false,

--- a/packages/sdk-react/src/components/providers/FusionAuthProvider.tsx
+++ b/packages/sdk-react/src/components/providers/FusionAuthProvider.tsx
@@ -32,10 +32,8 @@ const FusionAuthProvider: FC<
 
   const [isLoggedIn, setIsLoggedIn] = useState(core.isLoggedIn);
 
-  const { startLogin, startLogout, startRegister } = useRedirecting(
-    core,
-    config.onRedirect,
-  );
+  const { manageAccount, startLogin, startLogout, startRegister } =
+    useRedirecting(core, config.onRedirect);
 
   const { isFetchingUserInfo, userInfo, fetchUserInfo, error } = useUserInfo(
     core,
@@ -46,8 +44,6 @@ const FusionAuthProvider: FC<
     core,
     config.shouldAutoRefresh ?? false,
   );
-
-  const manageAccount = () => core.manageAccount();
 
   const providerValue: FusionAuthProviderContext = {
     startLogin,

--- a/packages/sdk-react/src/components/providers/FusionAuthProvider.tsx
+++ b/packages/sdk-react/src/components/providers/FusionAuthProvider.tsx
@@ -47,6 +47,8 @@ const FusionAuthProvider: FC<
     config.shouldAutoRefresh ?? false,
   );
 
+  const manageAccount = () => core.manageAccount();
+
   const providerValue: FusionAuthProviderContext = {
     startLogin,
     startRegister,
@@ -58,6 +60,7 @@ const FusionAuthProvider: FC<
     refreshToken,
     initAutoRefresh,
     fetchUserInfo,
+    manageAccount,
   };
 
   return (

--- a/packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts
+++ b/packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts
@@ -47,6 +47,12 @@ export interface FusionAuthProviderContext {
   startLogout: () => void;
 
   /**
+   * Redirects to [self service account management](https://fusionauth.io/docs/lifecycle/manage-users/account-management/)
+   * Self service account management is only available in FusionAuth paid plans.
+   */
+  manageAccount: () => void;
+
+  /**
    * Refreshes the access token a single time.
    * This is handled automatically if the SDK is configured with `shouldAutoRefresh`.
    */

--- a/packages/sdk-react/src/components/providers/hooks/useRedirecting.ts
+++ b/packages/sdk-react/src/components/providers/hooks/useRedirecting.ts
@@ -5,6 +5,7 @@ export function useRedirecting(
   core: SDKCore,
   onRedirect?: (state?: string) => void,
 ) {
+  const manageAccount = useCallback(() => core.manageAccount(), [core]);
   const startLogin = useCallback(
     (state?: string) => core.startLogin(state),
     [core],
@@ -20,6 +21,7 @@ export function useRedirecting(
   }, [core, onRedirect]);
 
   return {
+    manageAccount,
     startLogin,
     startRegister,
     startLogout,

--- a/packages/sdk-react/src/components/ui/FusionAuthAccountButton/FusionAuthAccountButton.test.tsx
+++ b/packages/sdk-react/src/components/ui/FusionAuthAccountButton/FusionAuthAccountButton.test.tsx
@@ -1,0 +1,24 @@
+import { screen, render, fireEvent } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+
+import { FusionAuthAccountButton } from '.';
+import { FusionAuthProvider } from '../../providers/FusionAuthProvider';
+import { mockUseFusionAuth } from '../../../testing-tools/mocks/mockUseFusionAuth';
+import { TEST_CONFIG } from '../../../testing-tools/mocks/testConfig';
+
+describe('FusionAuthAccountButton', () => {
+  test('Login button will call the useFusionAuth hook', () => {
+    const startLogin = vi.fn();
+    mockUseFusionAuth({ startLogin });
+
+    const stateValue = 'state-value-for-login';
+    render(
+      <FusionAuthProvider {...TEST_CONFIG}>
+        <FusionAuthAccountButton state={stateValue} />
+      </FusionAuthProvider>,
+    );
+
+    fireEvent.click(screen.getByText('Manage Account'));
+    expect(startLogin).toHaveBeenCalledWith(stateValue);
+  });
+});

--- a/packages/sdk-react/src/components/ui/FusionAuthAccountButton/FusionAuthAccountButton.test.tsx
+++ b/packages/sdk-react/src/components/ui/FusionAuthAccountButton/FusionAuthAccountButton.test.tsx
@@ -7,18 +7,17 @@ import { mockUseFusionAuth } from '../../../testing-tools/mocks/mockUseFusionAut
 import { TEST_CONFIG } from '../../../testing-tools/mocks/testConfig';
 
 describe('FusionAuthAccountButton', () => {
-  test('Login button will call the useFusionAuth hook', () => {
-    const startLogin = vi.fn();
-    mockUseFusionAuth({ startLogin });
+  test('Manage Account button will call the useFusionAuth hook', () => {
+    const manageAccount = vi.fn();
+    mockUseFusionAuth({ manageAccount });
 
-    const stateValue = 'state-value-for-login';
     render(
       <FusionAuthProvider {...TEST_CONFIG}>
-        <FusionAuthAccountButton state={stateValue} />
+        <FusionAuthAccountButton />
       </FusionAuthProvider>,
     );
 
     fireEvent.click(screen.getByText('Manage Account'));
-    expect(startLogin).toHaveBeenCalledWith(stateValue);
+    expect(manageAccount).toHaveBeenCalled();
   });
 });

--- a/packages/sdk-react/src/components/ui/FusionAuthAccountButton/index.tsx
+++ b/packages/sdk-react/src/components/ui/FusionAuthAccountButton/index.tsx
@@ -6,17 +6,16 @@ import styles from '#styles/button.module.scss';
 
 interface Props {
   className?: string;
-  state?: string;
 }
 
-export const FusionAuthAccountButton: FC<Props> = ({ className, state }) => {
-  const { startLogin } = useFusionAuth();
+export const FusionAuthAccountButton: FC<Props> = ({ className }) => {
+  const { manageAccount } = useFusionAuth();
 
   return (
     <button
       className={classNames(styles.fusionAuthButton, className)}
       type="button"
-      onClick={() => startLogin(state)}
+      onClick={manageAccount}
     >
       Manage Account
     </button>

--- a/packages/sdk-react/src/components/ui/FusionAuthAccountButton/index.tsx
+++ b/packages/sdk-react/src/components/ui/FusionAuthAccountButton/index.tsx
@@ -1,0 +1,24 @@
+import { FC } from 'react';
+import classNames from 'classnames';
+
+import { useFusionAuth } from '#components/providers/FusionAuthProvider';
+import styles from '#styles/button.module.scss';
+
+interface Props {
+  className?: string;
+  state?: string;
+}
+
+export const FusionAuthAccountButton: FC<Props> = ({ className, state }) => {
+  const { startLogin } = useFusionAuth();
+
+  return (
+    <button
+      className={classNames(styles.fusionAuthButton, className)}
+      type="button"
+      onClick={() => startLogin(state)}
+    >
+      Manage Account
+    </button>
+  );
+};

--- a/packages/sdk-react/src/index.ts
+++ b/packages/sdk-react/src/index.ts
@@ -3,6 +3,7 @@ export * from './components/providers/FusionAuthProviderConfig';
 export * from './components/providers/FusionAuthProviderContext';
 
 export * from './components/ui/FusionAuthLoginButton';
+export * from './components/ui/FusionAuthAccountButton';
 export * from './components/ui/FusionAuthLogoutButton';
 export * from './components/ui/FusionAuthRegisterButton';
 export * from './components/ui/RequireAuth';

--- a/packages/sdk-react/src/testing-tools/mocks/createContextMock.ts
+++ b/packages/sdk-react/src/testing-tools/mocks/createContextMock.ts
@@ -11,6 +11,7 @@ export const createContextMock = (
   userInfo: context.userInfo ?? null,
   refreshToken: context.refreshToken ?? vi.fn(),
   initAutoRefresh: context.initAutoRefresh ?? vi.fn(),
+  manageAccount: context.manageAccount ?? vi.fn(),
   isFetchingUserInfo: context.isFetchingUserInfo ?? false,
   error: context.error ?? null,
   fetchUserInfo:


### PR DESCRIPTION
Account Management functionality and button

Complete issue https://github.com/FusionAuth/fusionauth-javascript-sdk/issues/32 for the React SDK (https://github.com/FusionAuth/fusionauth-javascript-sdk/issues/129).

Add account management function and button for React SDK.

The button component is registered as `FusionAuthAccountButton`

#### Pre-Merge Checklist (if applicable)

- [x] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.
