### PR TITLE
Expose factory from Vue SDK

### DIFF
--- a/packages/sdk-vue/src/FusionAuthVuePlugin.ts
+++ b/packages/sdk-vue/src/FusionAuthVuePlugin.ts
@@ -1,0 +1,52 @@
+import { App } from 'vue';
+import { FusionAuth, FusionAuthConfig } from './types.ts';
+import * as components from './components/index.ts';
+import { fusionAuthKey } from './injectionSymbols.ts';
+import { createFusionAuth } from './createFusionAuth/index.ts';
+
+type FusionAuthInstantiated = { instance: FusionAuth };
+
+/**
+ * Installation method for the FusionAuthVuePlugin.
+ *
+ * @category Plugin
+ * @param {App} app - The Vue app instance.
+ * @param {FusionAuthConfig | FusionAuthInstantiated} options - The configuration options for the plugin or an object containing a FusionAuth instance.
+ * @throws {Error} Will throw an error if the required options are missing.
+ */
+const FusionAuthVuePlugin = {
+  install(app: App, options: FusionAuthConfig | FusionAuthInstantiated) {
+    let fusionAuth: FusionAuth;
+
+    if ('instance' in options) {
+      fusionAuth = options.instance;
+    } else {
+      validateConfig(options);
+      fusionAuth = createFusionAuth(options);
+    }
+
+    // Register the instance
+    app.provide(fusionAuthKey, fusionAuth);
+
+    // Register the components
+    Object.entries(components).forEach(([key, component]) => {
+      app.component(key, component);
+    });
+  },
+};
+
+function validateConfig(config: FusionAuthConfig) {
+  if (!config.clientId) {
+    throw new Error('clientId is required');
+  }
+
+  if (!config.serverUrl) {
+    throw new Error('serverUrl is required');
+  }
+
+  if (!config.redirectUri) {
+    throw new Error('redirectUri is required');
+  }
+}
+
+export default FusionAuthVuePlugin;

--- a/packages/sdk-vue/src/index.ts
+++ b/packages/sdk-vue/src/index.ts
@@ -1,43 +1,6 @@
-import { App } from 'vue';
-import { FusionAuthConfig } from './types.ts';
-import * as components from './components';
-import { fusionAuthKey } from './injectionSymbols.ts';
-import { createFusionAuth } from './createFusionAuth';
-
-/**
- * Installation method for the FusionAuthVuePlugin.
- *
- * @category Plugin
- * @param {App} app - The Vue app instance.
- * @param {FusionAuthConfig} options - The configuration options for the plugin.
- * @throws {Error} Will throw an error if the required options are missing.
- */
-const FusionAuthVuePlugin = {
-  install(app: App, options: FusionAuthConfig) {
-    // Validate options
-    if (!options.clientId) {
-      throw new Error('clientId is required');
-    }
-
-    if (!options.serverUrl) {
-      throw new Error('serverUrl is required');
-    }
-
-    if (!options.redirectUri) {
-      throw new Error('redirectUri is required');
-    }
-
-    app.provide(fusionAuthKey, createFusionAuth(options));
-
-    // Register the components
-    Object.entries(components).forEach(([key, component]) => {
-      app.component(key, component);
-    });
-  },
-};
-
-export default FusionAuthVuePlugin;
-
 export * from './components';
 export * from './composables/useFusionAuth';
 export * from './types';
+export * from './createFusionAuth/index';
+export * from './injectionSymbols';
+export { default } from './FusionAuthVuePlugin';


### PR DESCRIPTION
## What is this PR and why do we need it?
#104
This is to expose the `createFusionAuth`--factory previously not an exported member of the module. This will make the plugin more flexible in terms of how users want to instantiate it.

This makes it possible to instantiate fusionauth outside of the plugin, passing in the instance. See #104 for the original suggestion.

We'll follow this up with a README update to include an example, but it shouldn't be merged until the next version is released. [PR Here](https://github.com/FusionAuth/fusionauth-javascript-sdk/pull/134)

**Testing**
You should be able to import `createFusionAuth` from the module. [This PR](https://github.com/FusionAuth/fusionauth-javascript-sdk/pull/134) adds an example of how to set up a nuxt plugin with the factory, if you'd like to try--though it's not necessarily in the scope of this PR) [Here's the nuxt app I've been using](https://github.com/JakeLo123/nuxt-app).

This is not a nuxt-specific change, just something that is probably only helpful to nuxt users.

#### Pre-Merge Checklist (if applicable)
- [x] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.
