### PR TITLE
Generic/typed UserInfo

### DIFF
--- a/packages/core/src/SDKCore/SDKCore.ts
+++ b/packages/core/src/SDKCore/SDKCore.ts
@@ -46,7 +46,7 @@ export class SDKCore {
     window.location.assign(this.urlHelper.getAccountManagementUrl());
   }
 
-  async fetchUserInfo() {
+  async fetchUserInfo<T = UserInfo>() {
     const userInfoResponse = await fetch(this.urlHelper.getMeUrl(), {
       credentials: 'include',
     });
@@ -57,7 +57,7 @@ export class SDKCore {
       );
     }
 
-    const userInfo: UserInfo = await userInfoResponse.json();
+    const userInfo: T = await userInfoResponse.json();
     return userInfo;
   }
 

--- a/packages/sdk-react/src/components/providers/Context.tsx
+++ b/packages/sdk-react/src/components/providers/Context.tsx
@@ -34,4 +34,6 @@ export type UserInfo = {
 };
 
 export const FusionAuthContext =
-  React.createContext<FusionAuthProviderContext>(defaultContext);
+  React.createContext<FusionAuthProviderContext<UserInfo | any>>(
+    defaultContext,
+  );

--- a/packages/sdk-react/src/components/providers/FusionAuthProvider.test.tsx
+++ b/packages/sdk-react/src/components/providers/FusionAuthProvider.test.tsx
@@ -16,10 +16,10 @@ import {
 } from '@fusionauth-sdk/core';
 import { TEST_CONFIG } from '#testing-tools/mocks/testConfig';
 
-function renderWithWrapper(config: FusionAuthProviderConfig) {
-  return renderHook(() => useFusionAuth(), {
+function renderWithWrapper<T = UserInfo>(config: FusionAuthProviderConfig) {
+  return renderHook(() => useFusionAuth<T>(), {
     wrapper: ({ children }: PropsWithChildren) => (
-      <FusionAuthProvider {...config}>{children}</FusionAuthProvider>
+      <FusionAuthProvider<T> {...config}>{children}</FusionAuthProvider>
     ),
   });
 }
@@ -111,14 +111,17 @@ describe('FusionAuthProvider', () => {
   });
 
   test('Will fetch userInfo', async () => {
-    const user: UserInfo = { given_name: 'Mr. Userton' };
+    const user = {
+      name: 'Mr. Userton',
+      age: 501,
+    };
     const mockUserInfoResponse = {
       ok: true,
       json: () => Promise.resolve(user),
     } as Response;
     vi.spyOn(global, 'fetch').mockResolvedValueOnce(mockUserInfoResponse);
 
-    const { result } = renderWithWrapper(TEST_CONFIG);
+    const { result } = renderWithWrapper<typeof user>(TEST_CONFIG);
 
     expect(fetch).not.toHaveBeenCalled();
 
@@ -131,7 +134,8 @@ describe('FusionAuthProvider', () => {
 
     await waitFor(() => {
       expect(result.current.isFetchingUserInfo).toBe(false);
-      expect(result.current.userInfo).toBe(user);
+      expect(result.current.userInfo?.age).toBe(501);
+      expect(result.current.userInfo?.name).toBe('Mr. Userton');
     });
   });
 

--- a/packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts
+++ b/packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts
@@ -1,7 +1,7 @@
 import { UserInfo } from './Context';
 
 /** The context provided by FusionAuth React SDK */
-export interface FusionAuthProviderContext {
+export interface FusionAuthProviderContext<T = UserInfo> {
   /**
    * Whether the user is logged in.
    */
@@ -10,14 +10,13 @@ export interface FusionAuthProviderContext {
   /**
    * Data fetched from the configured 'me' endpoint.
    */
-  userInfo: UserInfo | null;
+  userInfo: T | null;
 
   /**
    * Fetches user info from the 'me' endpoint.
    * This is handled automatically if the SDK is configured with `shouldAutoFetchUserInfo`.
-   * @returns {Promise<UserInfo>}
    */
-  fetchUserInfo: () => Promise<UserInfo | undefined>;
+  fetchUserInfo: () => Promise<T | undefined>;
 
   /**
    * Indicates that the fetchUserInfo call is unresolved.

--- a/packages/sdk-react/src/components/providers/hooks/useUserInfo.ts
+++ b/packages/sdk-react/src/components/providers/hooks/useUserInfo.ts
@@ -1,10 +1,13 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 
-import { SDKCore, UserInfo } from '@fusionauth-sdk/core';
+import { SDKCore } from '@fusionauth-sdk/core';
 
-export function useUserInfo(core: SDKCore, shouldAutoFetchUserInfo: boolean) {
+export function useUserInfo<T>(
+  core: SDKCore,
+  shouldAutoFetchUserInfo: boolean,
+) {
   const [isFetchingUserInfo, setIsFetchingUserInfo] = useState(false);
-  const [userInfo, setUserInfo] = useState<UserInfo | null>(null);
+  const [userInfo, setUserInfo] = useState<T | null>(null);
   const [error, setError] = useState<Error | null>(null);
 
   const fetchUserInfo = useCallback(async () => {
@@ -12,7 +15,7 @@ export function useUserInfo(core: SDKCore, shouldAutoFetchUserInfo: boolean) {
     setError(null);
 
     try {
-      const userInfo = await core.fetchUserInfo();
+      const userInfo = await core.fetchUserInfo<T>();
       setUserInfo(userInfo);
       return userInfo;
     } catch (error) {


### PR DESCRIPTION
## What is this PR and why do we need it?
#94 -- Users with a custom `/app/me` implementation may have a custom userInfo payload different from the default `UserInfo`. Users need a way to specify the shape of the object.

For example:
<img width="534" alt="image" src="https://github.com/FusionAuth/fusionauth-javascript-sdk/assets/49047386/5e2e2fa3-3381-4f58-bc81-633ee093084c">

#### Pre-Merge Checklist (if applicable)
- [x] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.
