### PR TITLE
Add generic/typed userInfo for FusionAuthService

### DIFF
--- a/packages/core/src/SDKCore/SDKCore.ts
+++ b/packages/core/src/SDKCore/SDKCore.ts
@@ -46,7 +46,7 @@ export class SDKCore {
     window.location.assign(this.urlHelper.getAccountManagementUrl());
   }
 
-  async fetchUserInfo() {
+  async fetchUserInfo<T = UserInfo>() {
     const userInfoResponse = await fetch(this.urlHelper.getMeUrl(), {
       credentials: 'include',
     });
@@ -57,7 +57,7 @@ export class SDKCore {
       );
     }
 
-    const userInfo: UserInfo = await userInfoResponse.json();
+    const userInfo: T = await userInfoResponse.json();
     return userInfo;
   }
 

--- a/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.spec.ts
+++ b/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.spec.ts
@@ -29,16 +29,21 @@ describe('FusionAuthService', () => {
   it('Can be configured to automatically handle getting userInfo', (done: DoneFn) => {
     mockIsLoggedIn();
 
-    const user = { email: 'richard@test.com' };
+    const user = {
+      email: 'richard@test.com',
+      customTrait: 'something special',
+    };
     spyOn(window, 'fetch').and.resolveTo(
       new Response(JSON.stringify(user), { status: 200 }),
     );
 
-    const service = configureTestingModule(config);
+    const service: FusionAuthService<typeof user> =
+      configureTestingModule(config);
 
     service.getUserInfoObservable().subscribe({
       next: userInfo => {
         expect(userInfo.email).toBe('richard@test.com');
+        expect(userInfo.customTrait).toBe('something special');
         done();
       },
     });

--- a/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.ts
+++ b/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.ts
@@ -13,7 +13,7 @@ import { FUSIONAUTH_SERVICE_CONFIG } from './injectionToken';
 @Injectable({
   providedIn: 'root',
 })
-export class FusionAuthService {
+export class FusionAuthService<T = UserInfo> {
   private core: SDKCore;
   private autoRefreshTimer?: NodeJS.Timeout;
   private isLoggedInSubject: BehaviorSubject<boolean>;
@@ -74,11 +74,11 @@ export class FusionAuthService {
   getUserInfoObservable(callbacks?: {
     onBegin?: () => void;
     onDone?: () => void;
-  }): Observable<UserInfo> {
+  }): Observable<T> {
     callbacks?.onBegin?.();
-    return new Observable<UserInfo>(observer => {
+    return new Observable<T>(observer => {
       this.core
-        .fetchUserInfo()
+        .fetchUserInfo<T>()
         .then(userInfo => {
           observer.next(userInfo);
         })
@@ -99,8 +99,8 @@ export class FusionAuthService {
    * Fetches userInfo from the 'me' endpoint.
    * @throws {Error} - if an error occurred while fetching.
    */
-  async getUserInfo(): Promise<UserInfo> {
-    return await this.core.fetchUserInfo();
+  async getUserInfo<T>(): Promise<T> {
+    return await this.core.fetchUserInfo<T>();
   }
 
   /**

--- a/packages/sdk-react/src/components/providers/Context.tsx
+++ b/packages/sdk-react/src/components/providers/Context.tsx
@@ -34,4 +34,6 @@ export type UserInfo = {
 };
 
 export const FusionAuthContext =
-  React.createContext<FusionAuthProviderContext>(defaultContext);
+  React.createContext<FusionAuthProviderContext<UserInfo | any>>(
+    defaultContext,
+  );

--- a/packages/sdk-react/src/components/providers/FusionAuthProvider.test.tsx
+++ b/packages/sdk-react/src/components/providers/FusionAuthProvider.test.tsx
@@ -16,10 +16,10 @@ import {
 } from '@fusionauth-sdk/core';
 import { TEST_CONFIG } from '#testing-tools/mocks/testConfig';
 
-function renderWithWrapper(config: FusionAuthProviderConfig) {
-  return renderHook(() => useFusionAuth(), {
+function renderWithWrapper<T = UserInfo>(config: FusionAuthProviderConfig) {
+  return renderHook(() => useFusionAuth<T>(), {
     wrapper: ({ children }: PropsWithChildren) => (
-      <FusionAuthProvider {...config}>{children}</FusionAuthProvider>
+      <FusionAuthProvider<T> {...config}>{children}</FusionAuthProvider>
     ),
   });
 }
@@ -111,14 +111,17 @@ describe('FusionAuthProvider', () => {
   });
 
   test('Will fetch userInfo', async () => {
-    const user: UserInfo = { given_name: 'Mr. Userton' };
+    const user = {
+      name: 'Mr. Userton',
+      age: 501,
+    };
     const mockUserInfoResponse = {
       ok: true,
       json: () => Promise.resolve(user),
     } as Response;
     vi.spyOn(global, 'fetch').mockResolvedValueOnce(mockUserInfoResponse);
 
-    const { result } = renderWithWrapper(TEST_CONFIG);
+    const { result } = renderWithWrapper<typeof user>(TEST_CONFIG);
 
     expect(fetch).not.toHaveBeenCalled();
 
@@ -131,7 +134,8 @@ describe('FusionAuthProvider', () => {
 
     await waitFor(() => {
       expect(result.current.isFetchingUserInfo).toBe(false);
-      expect(result.current.userInfo).toBe(user);
+      expect(result.current.userInfo?.age).toBe(501);
+      expect(result.current.userInfo?.name).toBe('Mr. Userton');
     });
   });
 

--- a/packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts
+++ b/packages/sdk-react/src/components/providers/FusionAuthProviderContext.ts
@@ -1,7 +1,7 @@
 import { UserInfo } from './Context';
 
 /** The context provided by FusionAuth React SDK */
-export interface FusionAuthProviderContext {
+export interface FusionAuthProviderContext<T = UserInfo> {
   /**
    * Whether the user is logged in.
    */
@@ -10,14 +10,13 @@ export interface FusionAuthProviderContext {
   /**
    * Data fetched from the configured 'me' endpoint.
    */
-  userInfo: UserInfo | null;
+  userInfo: T | null;
 
   /**
    * Fetches user info from the 'me' endpoint.
    * This is handled automatically if the SDK is configured with `shouldAutoFetchUserInfo`.
-   * @returns {Promise<UserInfo>}
    */
-  fetchUserInfo: () => Promise<UserInfo | undefined>;
+  fetchUserInfo: () => Promise<T | undefined>;
 
   /**
    * Indicates that the fetchUserInfo call is unresolved.

--- a/packages/sdk-react/src/components/providers/hooks/useUserInfo.ts
+++ b/packages/sdk-react/src/components/providers/hooks/useUserInfo.ts
@@ -1,10 +1,13 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 
-import { SDKCore, UserInfo } from '@fusionauth-sdk/core';
+import { SDKCore } from '@fusionauth-sdk/core';
 
-export function useUserInfo(core: SDKCore, shouldAutoFetchUserInfo: boolean) {
+export function useUserInfo<T>(
+  core: SDKCore,
+  shouldAutoFetchUserInfo: boolean,
+) {
   const [isFetchingUserInfo, setIsFetchingUserInfo] = useState(false);
-  const [userInfo, setUserInfo] = useState<UserInfo | null>(null);
+  const [userInfo, setUserInfo] = useState<T | null>(null);
   const [error, setError] = useState<Error | null>(null);
 
   const fetchUserInfo = useCallback(async () => {
@@ -12,7 +15,7 @@ export function useUserInfo(core: SDKCore, shouldAutoFetchUserInfo: boolean) {
     setError(null);
 
     try {
-      const userInfo = await core.fetchUserInfo();
+      const userInfo = await core.fetchUserInfo<T>();
       setUserInfo(userInfo);
       return userInfo;
     } catch (error) {

--- a/packages/sdk-vue/src/FusionAuthVuePlugin.ts
+++ b/packages/sdk-vue/src/FusionAuthVuePlugin.ts
@@ -1,0 +1,52 @@
+import { App } from 'vue';
+import { FusionAuth, FusionAuthConfig } from './types.ts';
+import * as components from './components/index.ts';
+import { fusionAuthKey } from './injectionSymbols.ts';
+import { createFusionAuth } from './createFusionAuth/index.ts';
+
+type FusionAuthInstantiated = { instance: FusionAuth };
+
+/**
+ * Installation method for the FusionAuthVuePlugin.
+ *
+ * @category Plugin
+ * @param {App} app - The Vue app instance.
+ * @param {FusionAuthConfig | FusionAuthInstantiated} options - The configuration options for the plugin or an object containing a FusionAuth instance.
+ * @throws {Error} Will throw an error if the required options are missing.
+ */
+const FusionAuthVuePlugin = {
+  install(app: App, options: FusionAuthConfig | FusionAuthInstantiated) {
+    let fusionAuth: FusionAuth;
+
+    if ('instance' in options) {
+      fusionAuth = options.instance;
+    } else {
+      validateConfig(options);
+      fusionAuth = createFusionAuth(options);
+    }
+
+    // Register the instance
+    app.provide(fusionAuthKey, fusionAuth);
+
+    // Register the components
+    Object.entries(components).forEach(([key, component]) => {
+      app.component(key, component);
+    });
+  },
+};
+
+function validateConfig(config: FusionAuthConfig) {
+  if (!config.clientId) {
+    throw new Error('clientId is required');
+  }
+
+  if (!config.serverUrl) {
+    throw new Error('serverUrl is required');
+  }
+
+  if (!config.redirectUri) {
+    throw new Error('redirectUri is required');
+  }
+}
+
+export default FusionAuthVuePlugin;

--- a/packages/sdk-vue/src/index.ts
+++ b/packages/sdk-vue/src/index.ts
@@ -1,43 +1,6 @@
-import { App } from 'vue';
-import { FusionAuthConfig } from './types.ts';
-import * as components from './components';
-import { fusionAuthKey } from './injectionSymbols.ts';
-import { createFusionAuth } from './createFusionAuth';
-
-/**
- * Installation method for the FusionAuthVuePlugin.
- *
- * @category Plugin
- * @param {App} app - The Vue app instance.
- * @param {FusionAuthConfig} options - The configuration options for the plugin.
- * @throws {Error} Will throw an error if the required options are missing.
- */
-const FusionAuthVuePlugin = {
-  install(app: App, options: FusionAuthConfig) {
-    // Validate options
-    if (!options.clientId) {
-      throw new Error('clientId is required');
-    }
-
-    if (!options.serverUrl) {
-      throw new Error('serverUrl is required');
-    }
-
-    if (!options.redirectUri) {
-      throw new Error('redirectUri is required');
-    }
-
-    app.provide(fusionAuthKey, createFusionAuth(options));
-
-    // Register the components
-    Object.entries(components).forEach(([key, component]) => {
-      app.component(key, component);
-    });
-  },
-};
-
-export default FusionAuthVuePlugin;
-
 export * from './components';
 export * from './composables/useFusionAuth';
 export * from './types';
+export * from './createFusionAuth/index';
+export * from './injectionSymbols';
+export { default } from './FusionAuthVuePlugin';


### PR DESCRIPTION
## What is this PR and why do we need it?
#135 -- adding an optional generic type to the FusionAuthService class so that `userInfo` can be custom typed. Defaults to [`UserInfo`](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/main/packages/sdk-angular/docs/interfaces/UserInfo.md)

#### Pre-Merge Checklist (if applicable)
- [x] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.