### PR TITLE
Add generic/typed userInfo for FusionAuthService

### DIFF
--- a/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.spec.ts
+++ b/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.spec.ts
@@ -29,16 +29,21 @@ describe('FusionAuthService', () => {
   it('Can be configured to automatically handle getting userInfo', (done: DoneFn) => {
     mockIsLoggedIn();
 
-    const user = { email: 'richard@test.com' };
+    const user = {
+      email: 'richard@test.com',
+      customTrait: 'something special',
+    };
     spyOn(window, 'fetch').and.resolveTo(
       new Response(JSON.stringify(user), { status: 200 }),
     );
 
-    const service = configureTestingModule(config);
+    const service: FusionAuthService<typeof user> =
+      configureTestingModule(config);
 
     service.getUserInfoObservable().subscribe({
       next: userInfo => {
         expect(userInfo.email).toBe('richard@test.com');
+        expect(userInfo.customTrait).toBe('something special');
         done();
       },
     });

--- a/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.ts
+++ b/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.ts
@@ -13,7 +13,7 @@ import { FUSIONAUTH_SERVICE_CONFIG } from './injectionToken';
 @Injectable({
   providedIn: 'root',
 })
-export class FusionAuthService {
+export class FusionAuthService<T = UserInfo> {
   private core: SDKCore;
   private autoRefreshTimer?: NodeJS.Timeout;
   private isLoggedInSubject: BehaviorSubject<boolean>;
@@ -74,11 +74,11 @@ export class FusionAuthService {
   getUserInfoObservable(callbacks?: {
     onBegin?: () => void;
     onDone?: () => void;
-  }): Observable<UserInfo> {
+  }): Observable<T> {
     callbacks?.onBegin?.();
-    return new Observable<UserInfo>(observer => {
+    return new Observable<T>(observer => {
       this.core
-        .fetchUserInfo()
+        .fetchUserInfo<T>()
         .then(userInfo => {
           observer.next(userInfo);
         })
@@ -99,8 +99,8 @@ export class FusionAuthService {
    * Fetches userInfo from the 'me' endpoint.
    * @throws {Error} - if an error occurred while fetching.
    */
-  async getUserInfo(): Promise<UserInfo> {
-    return await this.core.fetchUserInfo();
+  async getUserInfo<T>(): Promise<T> {
+    return await this.core.fetchUserInfo<T>();
   }
 
   /**


### PR DESCRIPTION
## What is this PR and why do we need it?
#135 -- adding an optional generic type to the FusionAuthService class so that `userInfo` can be custom typed. Defaults to [`UserInfo`](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/main/packages/sdk-angular/docs/interfaces/UserInfo.md)

#### Pre-Merge Checklist (if applicable)
- [x] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.