### PR TITLE
Add generic Userinfo to createFusionAuth for vue sdk

### DIFF
--- a/packages/sdk-vue/src/FusionAuthVuePlugin.ts
+++ b/packages/sdk-vue/src/FusionAuthVuePlugin.ts
@@ -1,4 +1,4 @@
-import { App } from 'vue';
+import { App, InjectionKey } from 'vue';
 import { FusionAuth, FusionAuthConfig } from './types.ts';
 import * as components from './components/index.ts';
 import { fusionAuthKey } from './injectionSymbols.ts';
@@ -26,7 +26,7 @@ const FusionAuthVuePlugin = {
     }
 
     // Register the instance
-    app.provide(fusionAuthKey, fusionAuth);
+    app.provide(fusionAuthKey as InjectionKey<FusionAuth>, fusionAuth);
 
     // Register the components
     Object.entries(components).forEach(([key, component]) => {

--- a/packages/sdk-vue/src/FusionAuthVuePlugin.ts
+++ b/packages/sdk-vue/src/FusionAuthVuePlugin.ts
@@ -3,8 +3,9 @@ import { FusionAuth, FusionAuthConfig } from './types.ts';
 import * as components from './components/index.ts';
 import { fusionAuthKey } from './injectionSymbols.ts';
 import { createFusionAuth } from './createFusionAuth/index.ts';
+import { UserInfo } from '@fusionauth-sdk/core';
 
-type FusionAuthInstantiated = { instance: FusionAuth };
+type FusionAuthInstantiated = { instance: FusionAuth<UserInfo | any> };
 
 /**
  * Installation method for the FusionAuthVuePlugin.

--- a/packages/sdk-vue/src/composables/useFusionAuth.ts
+++ b/packages/sdk-vue/src/composables/useFusionAuth.ts
@@ -1,8 +1,8 @@
 import { inject } from 'vue';
 import { fusionAuthKey } from '#/injectionSymbols';
-import type { FusionAuth } from '#/types';
+import type { FusionAuth, UserInfo } from '#/types';
 
-export const useFusionAuth = (): FusionAuth => {
+export const useFusionAuth = <T extends FusionAuth<UserInfo>>(): FusionAuth => {
   const fusionAuth = inject(fusionAuthKey);
 
   if (!fusionAuth) {
@@ -10,5 +10,5 @@ export const useFusionAuth = (): FusionAuth => {
       'No FusionAuth instance found. Did you forget to call Vue.use(FusionAuthVuePlugin)?',
     );
   }
-  return fusionAuth;
+  return fusionAuth as T;
 };

--- a/packages/sdk-vue/src/composables/useFusionAuth.ts
+++ b/packages/sdk-vue/src/composables/useFusionAuth.ts
@@ -1,9 +1,9 @@
-import { inject } from 'vue';
+import { InjectionKey, inject } from 'vue';
 import { fusionAuthKey } from '#/injectionSymbols';
 import type { FusionAuth, UserInfo } from '#/types';
 
 export const useFusionAuth = <T = UserInfo>(): FusionAuth<T> => {
-  const fusionAuth = inject(fusionAuthKey);
+  const fusionAuth = inject(fusionAuthKey as InjectionKey<FusionAuth<T>>);
 
   if (!fusionAuth) {
     throw new Error(

--- a/packages/sdk-vue/src/composables/useFusionAuth.ts
+++ b/packages/sdk-vue/src/composables/useFusionAuth.ts
@@ -2,7 +2,7 @@ import { inject } from 'vue';
 import { fusionAuthKey } from '#/injectionSymbols';
 import type { FusionAuth, UserInfo } from '#/types';
 
-export const useFusionAuth = <T extends FusionAuth<UserInfo>>(): FusionAuth => {
+export const useFusionAuth = <T = UserInfo>(): FusionAuth<T> => {
   const fusionAuth = inject(fusionAuthKey);
 
   if (!fusionAuth) {
@@ -10,5 +10,5 @@ export const useFusionAuth = <T extends FusionAuth<UserInfo>>(): FusionAuth => {
       'No FusionAuth instance found. Did you forget to call Vue.use(FusionAuthVuePlugin)?',
     );
   }
-  return fusionAuth as T;
+  return fusionAuth;
 };

--- a/packages/sdk-vue/src/createFusionAuth/createFusionAuth.test.ts
+++ b/packages/sdk-vue/src/createFusionAuth/createFusionAuth.test.ts
@@ -49,6 +49,7 @@ describe('createFusionAuth', () => {
     await fusionAuth.getUserInfo();
 
     expect(fusionAuth.userInfo.value).toEqual(user);
+    expect(fusionAuth.userInfo.value.customTrait).toEqual(user.customTrait);
   });
 
   it('Handles a failed user info request', async () => {

--- a/packages/sdk-vue/src/createFusionAuth/createFusionAuth.test.ts
+++ b/packages/sdk-vue/src/createFusionAuth/createFusionAuth.test.ts
@@ -35,7 +35,11 @@ describe('createFusionAuth', () => {
   });
 
   it('Fetches userInfo', async () => {
-    const user = { given_name: 'JSON', family_name: 'Bourne' };
+    const user = {
+      given_name: 'JSON',
+      family_name: 'Bourne',
+      customTrait: 'additional info',
+    };
     const mockUserInfoResponse = new Response(JSON.stringify(user), {
       status: 200,
     });

--- a/packages/sdk-vue/src/createFusionAuth/createFusionAuth.ts
+++ b/packages/sdk-vue/src/createFusionAuth/createFusionAuth.ts
@@ -23,12 +23,12 @@ export const createFusionAuth = (config: FusionAuthConfig): FusionAuth => {
   const isGettingUserInfo = ref<boolean>(false);
   const error = ref<Error | null>(null);
 
-  async function getUserInfo() {
+  async function getUserInfo<T>() {
     isGettingUserInfo.value = true;
     error.value = null;
 
     try {
-      userInfo.value = await core.fetchUserInfo();
+      userInfo.value = await core.fetchUserInfo<T>();
       return userInfo.value;
     } catch (e) {
       error.value = e as Error;

--- a/packages/sdk-vue/src/createFusionAuth/createFusionAuth.ts
+++ b/packages/sdk-vue/src/createFusionAuth/createFusionAuth.ts
@@ -25,7 +25,7 @@ export const createFusionAuth = <T extends UserInfo>(
   const isGettingUserInfo = ref<boolean>(false);
   const error = ref<Error | null>(null);
 
-  async function getUserInfo<T>() {
+  async function getUserInfo() {
     isGettingUserInfo.value = true;
     error.value = null;
 

--- a/packages/sdk-vue/src/createFusionAuth/createFusionAuth.ts
+++ b/packages/sdk-vue/src/createFusionAuth/createFusionAuth.ts
@@ -4,9 +4,9 @@ import { FusionAuth, FusionAuthConfig, UserInfo } from '#/types';
 
 import { NuxtUseCookieAdapter } from './NuxtUseCookieAdapter';
 
-export const createFusionAuth = <T extends UserInfo>(
+export const createFusionAuth = <T = UserInfo>(
   config: FusionAuthConfig,
-): FusionAuth => {
+): FusionAuth<T> => {
   let cookieAdapter;
   if (config.nuxtUseCookie) {
     cookieAdapter = new NuxtUseCookieAdapter(config.nuxtUseCookie);
@@ -21,7 +21,7 @@ export const createFusionAuth = <T extends UserInfo>(
   });
 
   const isLoggedIn = ref<boolean>(core.isLoggedIn);
-  const userInfo = ref<T | null>(null) as Ref<UserInfo>;
+  const userInfo: Ref<T | null> = ref(null);
   const isGettingUserInfo = ref<boolean>(false);
   const error = ref<Error | null>(null);
 

--- a/packages/sdk-vue/src/createFusionAuth/createFusionAuth.ts
+++ b/packages/sdk-vue/src/createFusionAuth/createFusionAuth.ts
@@ -1,10 +1,12 @@
-import { ref } from 'vue';
+import { Ref, ref } from 'vue';
 import { SDKCore } from '@fusionauth-sdk/core';
 import { FusionAuth, FusionAuthConfig, UserInfo } from '#/types';
 
 import { NuxtUseCookieAdapter } from './NuxtUseCookieAdapter';
 
-export const createFusionAuth = (config: FusionAuthConfig): FusionAuth => {
+export const createFusionAuth = <T extends UserInfo>(
+  config: FusionAuthConfig,
+): FusionAuth => {
   let cookieAdapter;
   if (config.nuxtUseCookie) {
     cookieAdapter = new NuxtUseCookieAdapter(config.nuxtUseCookie);
@@ -19,7 +21,7 @@ export const createFusionAuth = (config: FusionAuthConfig): FusionAuth => {
   });
 
   const isLoggedIn = ref<boolean>(core.isLoggedIn);
-  const userInfo = ref<UserInfo | null>(null);
+  const userInfo = ref<T | null>(null) as Ref<UserInfo>;
   const isGettingUserInfo = ref<boolean>(false);
   const error = ref<Error | null>(null);
 

--- a/packages/sdk-vue/src/injectionSymbols.ts
+++ b/packages/sdk-vue/src/injectionSymbols.ts
@@ -1,4 +1,1 @@
-import { InjectionKey } from 'vue';
-import type { FusionAuth } from './types.ts';
-
-export const fusionAuthKey = Symbol('fusionAuth') as InjectionKey<FusionAuth>;
+export const fusionAuthKey = Symbol('fusionAuth');

--- a/packages/sdk-vue/src/types.ts
+++ b/packages/sdk-vue/src/types.ts
@@ -105,7 +105,7 @@ export interface UserInfo {
 /**
  * FusionAuth object provided at app-level by FusionAuthVuePlugin
  */
-export interface FusionAuth<T> {
+export interface FusionAuth<T = UserInfo> {
   /**
    * Whether the user is logged in.
    */

--- a/packages/sdk-vue/src/types.ts
+++ b/packages/sdk-vue/src/types.ts
@@ -105,7 +105,7 @@ export interface UserInfo {
 /**
  * FusionAuth object provided at app-level by FusionAuthVuePlugin
  */
-export interface FusionAuth<T = UserInfo> {
+export interface FusionAuth<T> {
   /**
    * Whether the user is logged in.
    */

--- a/packages/sdk-vue/src/types.ts
+++ b/packages/sdk-vue/src/types.ts
@@ -105,7 +105,7 @@ export interface UserInfo {
 /**
  * FusionAuth object provided at app-level by FusionAuthVuePlugin
  */
-export interface FusionAuth {
+export interface FusionAuth<T = UserInfo> {
   /**
    * Whether the user is logged in.
    */
@@ -116,12 +116,12 @@ export interface FusionAuth {
    * Internally updates `isFetchingUser` and `userInfo` refs, as well as `error` if the request fails.
    * @returns {Promise<UserInfo>}
    */
-  getUserInfo: () => Promise<UserInfo | undefined>;
+  getUserInfo: () => Promise<T | undefined>;
 
   /**
    * Data fetched from the configured 'me' endpoint.
    */
-  userInfo: Ref<UserInfo | null>;
+  userInfo: Ref<T | null>;
 
   /**
    * Indicates that the getUserInfo call is unresolved.

--- a/packages/sdk-vue/src/utilsForTests/index.ts
+++ b/packages/sdk-vue/src/utilsForTests/index.ts
@@ -1,4 +1,4 @@
-import { ref } from 'vue';
+import { InjectionKey, ref } from 'vue';
 import { vi } from 'vitest';
 
 import type { FusionAuth } from '..';
@@ -13,7 +13,7 @@ export const getMockFusionAuth = ({
   userInfo = ref(null),
 }: Partial<FusionAuth>) => {
   return {
-    key: fusionAuthKey as symbol,
+    key: fusionAuthKey as InjectionKey<FusionAuth>,
     mockedValues: {
       login,
       logout,


### PR DESCRIPTION
## What is this PR and why do we need it?

#139  -- adding an optional generic type to createFusionAuth so that `UserInfo` can be custom typed. Defaults to [`UserInfo`](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/main/packages/sdk-vue/docs/interfaces/types.UserInfo.md)

#### Pre-Merge Checklist (if applicable)

- [x] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.
