### PR TITLE
Include status code with error passed to `onAutoRefreshFailure`

### DIFF
--- a/packages/core/src/SDKCore/SDKCore.ts
+++ b/packages/core/src/SDKCore/SDKCore.ts
@@ -69,12 +69,14 @@ export class SDKCore {
         'Content-Type': 'text/plain',
       },
     });
-
     if (!(response.status >= 200 && response.status < 300)) {
-      const message =
-        (await response?.text()) ||
-        'Error refreshing access token in fusionauth';
-      throw new Error(message);
+      const errorDetails = {
+        status: response.status,
+        details:
+          (await response?.text()) ||
+          'Failed to refresh fusionauth access token',
+      };
+      throw new Error(JSON.stringify(errorDetails));
     }
 
     // a successful request means that app_exp was bumped into the future.

--- a/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.spec.ts
+++ b/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.spec.ts
@@ -126,19 +126,4 @@ describe('FusionAuthService', () => {
 
     expect(onRedirect).toHaveBeenCalledWith('/welcome-page');
   });
-
-  it("Invokes an 'onAutoRefreshFailure' callback", fakeAsync(() => {
-    mockIsLoggedIn();
-    spyOn(window, 'fetch').and.resolveTo(new Response(null, { status: 400 }));
-    const onAutoRefreshFailure = jasmine.createSpy('onAutoRefreshFailureSpy');
-
-    configureTestingModule({
-      ...config,
-      shouldAutoRefresh: true,
-      onAutoRefreshFailure,
-    });
-
-    tick(60 * 60 * 1000);
-    expect(onAutoRefreshFailure).not.toHaveBeenCalledWith();
-  }));
 });

--- a/packages/sdk-react/src/components/providers/FusionAuthProvider.test.tsx
+++ b/packages/sdk-react/src/components/providers/FusionAuthProvider.test.tsx
@@ -233,9 +233,9 @@ describe('FusionAuthProvider', () => {
     vi.useFakeTimers();
     mockIsLoggedIn(); // mock logged in -- expires in 1 hour
 
-    const failureData = { message: 'cannot refresh token' };
+    const failureData = JSON.stringify({ message: 'cannot refresh token' });
     vi.spyOn(global, 'fetch').mockResolvedValueOnce(
-      new Response(JSON.stringify(failureData), { status: 400 }),
+      new Response(failureData, { status: 400 }),
     );
 
     const onAutoRefreshFailure = vi.fn();
@@ -250,7 +250,12 @@ describe('FusionAuthProvider', () => {
 
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(onAutoRefreshFailure).toHaveBeenCalledWith(
-      Error(JSON.stringify({ message: 'cannot refresh token' })),
+      Error(
+        JSON.stringify({
+          status: 400,
+          details: failureData,
+        }),
+      ),
     );
   });
 });

--- a/packages/sdk-vue/src/createFusionAuth/createFusionAuth.test.ts
+++ b/packages/sdk-vue/src/createFusionAuth/createFusionAuth.test.ts
@@ -95,7 +95,12 @@ describe('createFusionAuth', () => {
     await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
 
     expect(onAutoRefreshFailure).toHaveBeenCalledWith(
-      Error(JSON.stringify({ msg: 'could not refresh access token' })),
+      Error(
+        JSON.stringify({
+          status: 400,
+          details: JSON.stringify({ msg: 'could not refresh access token' }),
+        }),
+      ),
     );
   });
 


### PR DESCRIPTION
## What is this PR and why do we need it?
#151 -- Include status code with error passed to `onAutoRefreshFailure`. The message of the error returned should be a stringified object with `details` and `status`.

*If you are running tests on this branch or after it's merged to `main`, you will need to rebuild the core package to satisfy some tests.

#### Pre-Merge Checklist (if applicable)
- [x] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.
