### PR TITLE
Fix 404 link in vue-sdk changelog

### DIFF
--- a/packages/sdk-vue/CHANGES.md
+++ b/packages/sdk-vue/CHANGES.md
@@ -2,7 +2,7 @@ fusionauth-vue-sdk Changes
 
 Changes in 1.2.0
 
-- [`postLogoutRedirectUri`](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/main/packages/sdk-vue/docs/interfaces/types.FusionAuthConfig.md#postlogoutredirecturi) config option added.
+- [`postLogoutRedirectUri`](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/main/packages/sdk-vue/docs/interfaces/FusionAuthConfig.md#postlogoutredirecturi) config option added.
 - [`createFusionAuth`](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/main/packages/sdk-vue/docs/modules.md#createfusionauth) factory function is now an exported member of the package. This was suggested in issue [#104](https://github.com/FusionAuth/fusionauth-javascript-sdk/issues/104) and provides more flexibility in setting up your fusionauth plugin.
 - `manageAccount` function and button added. [Self service account management](https://fusionauth.io/docs/lifecycle/manage-users/account-management/) is only available in FusionAuth paid plans.
 - `userInfo` can now be custom typed with an optional generic argument. This may be helpful for SDK users with a non-hosted backend. Below is an example of what it may look like.


### PR DESCRIPTION
## What is this PR and why do we need it?
One of the links in our changelog was bunk. It should link to the generated api docs for the mentioned property `postLogoutRedirectUri`

#### Pre-Merge Checklist (if applicable)
- [x] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.
