### PR TITLE
Angular SDK v1.3.0

### DIFF
--- a/packages/sdk-angular/CHANGES.md
+++ b/packages/sdk-angular/CHANGES.md
@@ -1,5 +1,9 @@
 @fusionauth/angular-sdk Changes
 
+Changes in 1.3.0
+
+- The `error` passed to [`onAutoRefreshFailure`](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/main/packages/sdk-angular/docs/interfaces/FusionAuthConfig.md#onautorefreshfailure) should now include the response status code. See [issue #151](https://github.com/FusionAuth/fusionauth-javascript-sdk/issues/151).
+
 Changes in 1.2.0
 
 - `userInfo` can now be custom typed with an optional generic argument. This may be helpful for SDK users with a non-hosted backend. Below is an example of what it looks like.

--- a/packages/sdk-angular/projects/fusionauth-angular-sdk/package.json
+++ b/packages/sdk-angular/projects/fusionauth-angular-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fusionauth/angular-sdk",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "peerDependencies": {
     "@angular/common": ">=17.2.0",
     "@angular/core": ">=17.2.0"


### PR DESCRIPTION
## What is this PR and why do we need it?
Angular SDK v1.3.0

The only change is absorbing [this small enhancement](url)!

- Bumps version number to 1.3.0
- Adds 1.3.0 section to changes.md
- No need to regenerate the docs or edit the README, since the public API didn't change.

#### Pre-Merge Checklist (if applicable)
- [x] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.
