### PR TITLE
Add core/RedirectHelper test coverage

### DIFF
--- a/packages/core/src/RedirectHelper/RedirectHelper.ts
+++ b/packages/core/src/RedirectHelper/RedirectHelper.ts
@@ -22,24 +22,25 @@ export class RedirectHelper {
   }
 
   handlePostRedirect(callback?: (state?: string) => void) {
-    const stateValue = this.stateValue ?? undefined;
-    callback?.(stateValue);
+    const didRedirect = Boolean(this.storage.getItem(this.REDIRECT_VALUE));
+    if (!didRedirect) {
+      return;
+    }
+
+    const state = this.state;
+    callback?.(state);
     this.storage.removeItem(this.REDIRECT_VALUE);
   }
 
-  get didRedirect() {
-    return Boolean(this.storage.getItem(this.REDIRECT_VALUE));
-  }
-
-  private get stateValue() {
+  private get state() {
     const redirectValue = this.storage.getItem(this.REDIRECT_VALUE);
 
     if (!redirectValue) {
-      return null;
+      return;
     }
 
     const [, ...stateValue] = redirectValue.split(':');
-    return stateValue.join(':');
+    return stateValue.join(':') || undefined;
   }
 
   private generateRandomString() {

--- a/packages/core/src/SDKCore/SDKCore.ts
+++ b/packages/core/src/SDKCore/SDKCore.ts
@@ -111,7 +111,7 @@ export class SDKCore {
   }
 
   handlePostRedirect(callback?: (state?: string) => void) {
-    if (this.isLoggedIn && this.redirectHelper.didRedirect) {
+    if (this.isLoggedIn) {
       this.redirectHelper.handlePostRedirect(callback);
     }
   }


### PR DESCRIPTION
## What is this PR and why do we need it?
Adding some integration coverage between `SDKCore` and `RedirectHelper`. Includes light refactor of some code in `RedirectHelper` for organization/readability

Testing...
- an indicator is set in localStorage before redirect to login or register.
- indicator is removed from localStorage post redirect
- `onRedirect` is invoked on cleanup
- `onRedirect` is not invoked if indicator is not present.
- the flow works as expected with state as `string | undefined`

#### Pre-Merge Checklist (if applicable)
- [x] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.
