### PR TITLE
SDK-React 2.4.1 release

### DIFF
--- a/packages/sdk-react/CHANGES.md
+++ b/packages/sdk-react/CHANGES.md
@@ -1,5 +1,9 @@
 fusionauth-react-sdk Changes
 
+Changes in 2.4.1
+
+- Fix the bug where the user is logged out on a successful token refresh.
+
 Changes in 2.4.0
 
 - Include the response status code in the error passed to [onAutoRefreshFailure](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/main/packages/sdk-react/docs/interfaces/providers_FusionAuthProviderConfig.FusionAuthProviderConfig.md#onautorefreshfailure). See issue [#151](https://github.com/FusionAuth/fusionauth-javascript-sdk/issues/151).

--- a/packages/sdk-react/CHANGES.md
+++ b/packages/sdk-react/CHANGES.md
@@ -2,8 +2,7 @@ fusionauth-react-sdk Changes
 
 Changes in 2.4.1
 
-- Fix the bug where the user is logged out on a successful token refresh.
-Resolved in PR [161](https://github.com/FusionAuth/fusionauth-javascript-sdk/pull/161)
+- Fix the bug where the user is logged out on a successful token refresh. Resolved in PR [161](https://github.com/FusionAuth/fusionauth-javascript-sdk/pull/161).
 
 Changes in 2.4.0
 

--- a/packages/sdk-react/CHANGES.md
+++ b/packages/sdk-react/CHANGES.md
@@ -3,6 +3,7 @@ fusionauth-react-sdk Changes
 Changes in 2.4.1
 
 - Fix the bug where the user is logged out on a successful token refresh.
+Resolved in PR [161](https://github.com/FusionAuth/fusionauth-javascript-sdk/pull/161)
 
 Changes in 2.4.0
 

--- a/packages/sdk-react/package.json
+++ b/packages/sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fusionauth/react-sdk",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "private": false,
   "description": "FusionAuth solves the problem of building essential security without adding risk or distracting from your primary application",
   "type": "module",


### PR DESCRIPTION
## What is this PR and why do we need it?

Need to bump the release number and update the changes.md for the react SDK.

This is related to this other PR: https://github.com/FusionAuth/fusionauth-javascript-sdk/commit/7e3c84d0ef2f7e13185c822f1d1021ed94c32343 which has been tested, reviewed and merged.