### PR TITLE
Clear potentially existing refreshTokenTimeout in initAutoRefresh

### DIFF
--- a/packages/core/src/SDKCore/SDKCore.ts
+++ b/packages/core/src/SDKCore/SDKCore.ts
@@ -95,6 +95,8 @@ export class SDKCore {
   }
 
   initAutoRefresh(): NodeJS.Timeout | undefined {
+    clearTimeout(this.refreshTokenTimeout);
+    
     if (!this.isLoggedIn || this.isDisposed) {
       return;
     }


### PR DESCRIPTION
## What is this PR and why do we need it?

In React Strict mode, effects are run twice. This means that if the `shouldAutoRefresh` flag is on, the [following effect](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/d42b0b39ed06d08b6b319c25473c16843f5ba58c/packages/sdk-react/src/components/providers/hooks/useTokenRefresh.ts#L14-L18) will be triggered twice on first render:
```ts
useEffect(() => {
  if (shouldAutoRefresh) {
    initAutoRefresh();
  }
}, [initAutoRefresh, shouldAutoRefresh]);
```

In the SDK Core, the `initAutoRefresh` method will thus be called twice, setting two time-outs. However, only the last one will get tracked. When the `FusionAuthProvider` component gets re-rendered, it will create a new `core`, attempting to `dispose()` the old one. The `dispose` will successfully cancel the second timeout, but the first one is still running.


React `initAutoRefresh` 1
=> SDKCore `initAutoRefresh` sets `this.refreshTokenTimeout` (let's say to value 1)
React `initAutoRefresh` 2 (effect is re-run)
=> SDKCore `initAutoRefresh` sets `this.refreshTokenTimeout` (let's say to value 2)
=> `refreshTimeout 1` is not cleared and keeps running
React FusionAuthProvider rerenders
=> SDKCore `dispose` method is called, clearing `refreshTokenTimeout 2`

Eventually `refreshTimeout 1` will run and could potentially return a wrong value (in my case the clientId was not correct anymore)


#### Pre-Merge Checklist (if applicable)

- [ ] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.
