### PR TITLE
Fix react-sdk issue where `isLoggedIn` being set to false after successful token refresh

### DIFF
--- a/packages/sdk-react/src/components/providers/FusionAuthProvider.tsx
+++ b/packages/sdk-react/src/components/providers/FusionAuthProvider.tsx
@@ -6,7 +6,7 @@ import {
   useRef,
 } from 'react';
 
-import { SDKCore } from '@fusionauth-sdk/core';
+import { SDKConfig, SDKCore } from '@fusionauth-sdk/core';
 
 import { FusionAuthProviderConfig } from './FusionAuthProviderConfig';
 import {
@@ -18,10 +18,49 @@ import {
 import { FusionAuthContext, UserInfo as DefaultUserInfo } from './Context';
 import { FusionAuthProviderContext } from './FusionAuthProviderContext';
 
-function FusionAuthProvider<T = DefaultUserInfo>({
-  children,
-  ...config
-}: PropsWithChildren & FusionAuthProviderConfig) {
+function FusionAuthProvider<T = DefaultUserInfo>(
+  props: PropsWithChildren & FusionAuthProviderConfig,
+) {
+  const config: Omit<SDKConfig, 'cookieAdapter' | 'onTokenExpiration'> =
+    useMemo(
+      () => ({
+        serverUrl: props.serverUrl,
+        clientId: props.clientId,
+        redirectUri: props.redirectUri,
+        scope: props.scope,
+        postLogoutRedirectUri: props.postLogoutRedirectUri,
+        shouldAutoRefresh: props.shouldAutoRefresh,
+        shouldAutoFetchUserInfo: props.shouldAutoFetchUserInfo,
+        autoRefreshSecondsBeforeExpiry: props.autoRefreshSecondsBeforeExpiry,
+        onRedirect: props.onRedirect,
+        loginPath: props.loginPath,
+        logoutPath: props.logoutPath,
+        registerPath: props.registerPath,
+        tokenRefreshPath: props.tokenRefreshPath,
+        mePath: props.mePath,
+        accessTokenExpireCookieName: props.accessTokenExpireCookieName,
+        onAutoRefreshFailure: props.onAutoRefreshFailure,
+      }),
+      [
+        props.serverUrl,
+        props.clientId,
+        props.redirectUri,
+        props.scope,
+        props.postLogoutRedirectUri,
+        props.shouldAutoRefresh,
+        props.shouldAutoFetchUserInfo,
+        props.autoRefreshSecondsBeforeExpiry,
+        props.onRedirect,
+        props.loginPath,
+        props.logoutPath,
+        props.registerPath,
+        props.tokenRefreshPath,
+        props.mePath,
+        props.accessTokenExpireCookieName,
+        props.onAutoRefreshFailure,
+      ],
+    );
+
   const cookieAdapter = useCookieAdapter(config);
 
   const coreRef = useRef<SDKCore>();
@@ -70,7 +109,7 @@ function FusionAuthProvider<T = DefaultUserInfo>({
 
   return (
     <FusionAuthContext.Provider value={providerValue}>
-      {children}
+      {props.children}
     </FusionAuthContext.Provider>
   );
 }


### PR DESCRIPTION
## What is this PR and why do we need it?
Fixing issue #166.

This should ensure that the main provider for the react-sdk doesn't flip `isLoggedIn` when a token refresh is successful by placing the code to `getNewCore` inside the provider to keep it in the react life cycle. Using a [mutable ref object](https://react.dev/reference/react/useRef).

@synedra -- tagging you as a reviewer in case you'd like to take a look and make sure I didn't mistake your nice work on the `dispose` method. If I've misconstrued something, please let me know.

#### Pre-Merge Checklist (if applicable)
- [x] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.
