### PR TITLE
Fix: Error accessing cookies in fusionauth. If you are using SSR you must configure the SDK with a cookie adapter

### DIFF
--- a/packages/sdk-react/src/components/providers/FusionAuthProvider.tsx
+++ b/packages/sdk-react/src/components/providers/FusionAuthProvider.tsx
@@ -61,7 +61,7 @@ function FusionAuthProvider<T = DefaultUserInfo>(
       ],
     );
 
-  const cookieAdapter = useCookieAdapter(config);
+  const cookieAdapter = useCookieAdapter(props);
 
   const coreRef = useRef<SDKCore>();
   const core: SDKCore = useMemo<SDKCore>(() => {


### PR DESCRIPTION
## What is this PR and why do we need it?

When using the `next-client-cookies` as per documentation, the `nextCookieAdapter` is not passed as it's not included in the config. This causes the coreSDK to fail to grab the cookies. 

As the config object is using the `SDKConfig` and `FusionAuthProviderConfig` is expected, I've change the function parameter from `config` to `props` to pass the correct `FusionAuthProviderConfig` object forward.

#### Pre-Merge Checklist (if applicable)

- [ ] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.
