### PR TITLE
Export FUSIONAUTH_SERVICE_CONFIG injection token in the public api

### DIFF
--- a/packages/sdk-angular/projects/fusionauth-angular-sdk/src/public-api.ts
+++ b/packages/sdk-angular/projects/fusionauth-angular-sdk/src/public-api.ts
@@ -9,3 +9,4 @@ export * from './lib/components/fusionauth-register.button/fusion-auth-register-
 export * from './lib/components/fusionauth-account.button/fusion-auth-account-button.component';
 export * from './lib/fusion-auth.module';
 export * from './lib/types';
+export * from './lib/injectionToken';


### PR DESCRIPTION
Expose the FUSIONAUTH_SERVICE_CONFIG DI token to enable dynamic configuration via a useFactory function. This allows consumers to customize the FusionAuth service configuration at runtime.

Example usage:
```
imports: [FusionAuthModule],
providers: [
    {
      provide: FUSIONAUTH_SERVICE_CONFIG,
      useFactory: fusionAuthRemoteFactory,
      deps: [HttpClient],
    },
  ]
```

## What is this PR and why do we need it?

https://github.com/FusionAuth/fusionauth-javascript-sdk/issues/181

#### Pre-Merge Checklist (if applicable)

- [ ] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.
