### PR TITLE
Add `authParams` parameter to FusionAuthConfig

### DIFF
--- a/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts
+++ b/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts
@@ -71,6 +71,11 @@ export interface FusionAuthConfig {
    * The path to the me endpoint.
    */
   mePath?: string;
+
+  /**
+   * Additional params passed to loginPath typically `/app/login/`, which redirects to `/oauth2/authorize`. Example of this might be authParams = [{'response_type': 'code'}] or any params found at https://fusionauth.io/docs/lifecycle/authenticate-users/oauth/endpoints
+   */
+  authParams?: { [key: string]: string }[];
 }
 
 export interface UserInfo {

--- a/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts
+++ b/packages/sdk-react/src/components/providers/FusionAuthProviderConfig.ts
@@ -25,7 +25,7 @@ export interface FusionAuthProviderConfig {
   scope?: string;
 
   /**
-   * Additional params passed to loginPath typically `/app/login/`, which redirects to `/oauth2/authorize`. Example of this might be loginParams = [{idp_hint:'44449786-3dff-42a6-aac6-1f1ceecb6c46'}] or any params found at https://fusionauth.io/docs/lifecycle/authenticate-users/oauth/endpoints
+   * Additional params passed to loginPath typically `/app/login/`, which redirects to `/oauth2/authorize`. Example of this might be authParams = [{idp_hint:'44449786-3dff-42a6-aac6-1f1ceecb6c46'}] or any params found at https://fusionauth.io/docs/lifecycle/authenticate-users/oauth/endpoints
    */
   authParams?: { [key: string]: any }[];
 

--- a/packages/sdk-vue/src/types.ts
+++ b/packages/sdk-vue/src/types.ts
@@ -79,6 +79,11 @@ export interface FusionAuthConfig {
    * The path to the me endpoint.
    */
   mePath?: string;
+
+  /**
+   * Additional params passed to loginPath typically `/app/login/`, which redirects to `/oauth2/authorize`. Example of this might be authParams = [{'response_type': 'code'}] or any params found at https://fusionauth.io/docs/lifecycle/authenticate-users/oauth/endpoints
+   */
+  authParams?: { [key: string]: string }[];
 }
 
 /**


### PR DESCRIPTION
add `authParams` param
correct existing documentation

## What is this PR and why do we need it?

Currently the login process fails and reports `error=invalid_request&error_reason=missing_response_type&error_description=The+request+is+missing+a+required+parameter%3A+response_type` when using the SDK on angular and vue #159.

Adding this param allows developers to add the `repsonse_type` query parameter that is required according to the [docs](https://fusionauth.io/docs/lifecycle/authenticate-users/oauth/endpoints#request-headers).

#### Pre-Merge Checklist (if applicable)

- [ ] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.
No logic was changed. This parameter was added to a type def and is doing the same as is correspondent in the react sdk.
