### PR TITLE
Add auth params to Angular

### DIFF
--- a/packages/sdk-angular/CHANGES.md
+++ b/packages/sdk-angular/CHANGES.md
@@ -1,5 +1,9 @@
 @fusionauth/angular-sdk Changes
 
+Changes in 1.4.0
+
+- Adds `authParams` to the Angular module's `.forRoot()` config interface so you can pass additional params to the authorize flow, such as `tenantId`.
+
 Changes in 1.3.0
 
 - The `error` passed to [`onAutoRefreshFailure`](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/main/packages/sdk-angular/docs/interfaces/FusionAuthConfig.md#onautorefreshfailure) should now include the response status code. See [issue #151](https://github.com/FusionAuth/fusionauth-javascript-sdk/issues/151).

--- a/packages/sdk-angular/docs/classes/FusionAuthAccountButtonComponent.md
+++ b/packages/sdk-angular/docs/classes/FusionAuthAccountButtonComponent.md
@@ -24,8 +24,8 @@
 
 #### Parameters
 
-| Name         | Type                                                                                   |
-| :----------- | :------------------------------------------------------------------------------------- |
+| Name | Type |
+| :------ | :------ |
 | `fusionAuth` | [`FusionAuthService`](FusionAuthService.md)\<[`UserInfo`](../interfaces/UserInfo.md)\> |
 
 #### Returns
@@ -34,7 +34,7 @@
 
 #### Defined in
 
-[lib/components/fusionauth-account.button/fusion-auth-account-button.component.ts:10](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/components/fusionauth-account.button/fusion-auth-account-button.component.ts#L10)
+[lib/components/fusionauth-account.button/fusion-auth-account-button.component.ts:10](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/components/fusionauth-account.button/fusion-auth-account-button.component.ts#L10)
 
 ## Properties
 
@@ -44,7 +44,7 @@
 
 #### Defined in
 
-[lib/components/fusionauth-account.button/fusion-auth-account-button.component.ts:10](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/components/fusionauth-account.button/fusion-auth-account-button.component.ts#L10)
+[lib/components/fusionauth-account.button/fusion-auth-account-button.component.ts:10](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/components/fusionauth-account.button/fusion-auth-account-button.component.ts#L10)
 
 ## Methods
 
@@ -58,4 +58,4 @@
 
 #### Defined in
 
-[lib/components/fusionauth-account.button/fusion-auth-account-button.component.ts:12](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/components/fusionauth-account.button/fusion-auth-account-button.component.ts#L12)
+[lib/components/fusionauth-account.button/fusion-auth-account-button.component.ts:12](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/components/fusionauth-account.button/fusion-auth-account-button.component.ts#L12)

--- a/packages/sdk-angular/docs/classes/FusionAuthLoginButtonComponent.md
+++ b/packages/sdk-angular/docs/classes/FusionAuthLoginButtonComponent.md
@@ -25,8 +25,8 @@
 
 #### Parameters
 
-| Name         | Type                                                                                   |
-| :----------- | :------------------------------------------------------------------------------------- |
+| Name | Type |
+| :------ | :------ |
 | `fusionAuth` | [`FusionAuthService`](FusionAuthService.md)\<[`UserInfo`](../interfaces/UserInfo.md)\> |
 
 #### Returns
@@ -35,7 +35,7 @@
 
 #### Defined in
 
-[lib/components/fusionauth-login.button/fusion-auth-login-button.component.ts:12](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/components/fusionauth-login.button/fusion-auth-login-button.component.ts#L12)
+[lib/components/fusionauth-login.button/fusion-auth-login-button.component.ts:12](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/components/fusionauth-login.button/fusion-auth-login-button.component.ts#L12)
 
 ## Properties
 
@@ -45,9 +45,9 @@
 
 #### Defined in
 
-[lib/components/fusionauth-login.button/fusion-auth-login-button.component.ts:12](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/components/fusionauth-login.button/fusion-auth-login-button.component.ts#L12)
+[lib/components/fusionauth-login.button/fusion-auth-login-button.component.ts:12](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/components/fusionauth-login.button/fusion-auth-login-button.component.ts#L12)
 
----
+___
 
 ### state
 
@@ -55,7 +55,7 @@
 
 #### Defined in
 
-[lib/components/fusionauth-login.button/fusion-auth-login-button.component.ts:10](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/components/fusionauth-login.button/fusion-auth-login-button.component.ts#L10)
+[lib/components/fusionauth-login.button/fusion-auth-login-button.component.ts:10](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/components/fusionauth-login.button/fusion-auth-login-button.component.ts#L10)
 
 ## Methods
 
@@ -69,4 +69,4 @@
 
 #### Defined in
 
-[lib/components/fusionauth-login.button/fusion-auth-login-button.component.ts:14](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/components/fusionauth-login.button/fusion-auth-login-button.component.ts#L14)
+[lib/components/fusionauth-login.button/fusion-auth-login-button.component.ts:14](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/components/fusionauth-login.button/fusion-auth-login-button.component.ts#L14)

--- a/packages/sdk-angular/docs/classes/FusionAuthLogoutButtonComponent.md
+++ b/packages/sdk-angular/docs/classes/FusionAuthLogoutButtonComponent.md
@@ -24,8 +24,8 @@
 
 #### Parameters
 
-| Name         | Type                                                                                   |
-| :----------- | :------------------------------------------------------------------------------------- |
+| Name | Type |
+| :------ | :------ |
 | `fusionAuth` | [`FusionAuthService`](FusionAuthService.md)\<[`UserInfo`](../interfaces/UserInfo.md)\> |
 
 #### Returns
@@ -34,7 +34,7 @@
 
 #### Defined in
 
-[lib/components/fusionauth-logout.button/fusion-auth-logout-button.component.ts:10](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/components/fusionauth-logout.button/fusion-auth-logout-button.component.ts#L10)
+[lib/components/fusionauth-logout.button/fusion-auth-logout-button.component.ts:13](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/components/fusionauth-logout.button/fusion-auth-logout-button.component.ts#L13)
 
 ## Properties
 
@@ -44,7 +44,7 @@
 
 #### Defined in
 
-[lib/components/fusionauth-logout.button/fusion-auth-logout-button.component.ts:10](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/components/fusionauth-logout.button/fusion-auth-logout-button.component.ts#L10)
+[lib/components/fusionauth-logout.button/fusion-auth-logout-button.component.ts:13](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/components/fusionauth-logout.button/fusion-auth-logout-button.component.ts#L13)
 
 ## Methods
 
@@ -58,4 +58,4 @@
 
 #### Defined in
 
-[lib/components/fusionauth-logout.button/fusion-auth-logout-button.component.ts:12](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/components/fusionauth-logout.button/fusion-auth-logout-button.component.ts#L12)
+[lib/components/fusionauth-logout.button/fusion-auth-logout-button.component.ts:15](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/components/fusionauth-logout.button/fusion-auth-logout-button.component.ts#L15)

--- a/packages/sdk-angular/docs/classes/FusionAuthModule.md
+++ b/packages/sdk-angular/docs/classes/FusionAuthModule.md
@@ -30,8 +30,8 @@
 
 #### Parameters
 
-| Name               | Type                                                    |
-| :----------------- | :------------------------------------------------------ |
+| Name | Type |
+| :------ | :------ |
 | `fusionAuthConfig` | [`FusionAuthConfig`](../interfaces/FusionAuthConfig.md) |
 
 #### Returns
@@ -40,4 +40,4 @@
 
 #### Defined in
 
-[lib/fusion-auth.module.ts:26](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.module.ts#L26)
+[lib/fusion-auth.module.ts:26](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.module.ts#L26)

--- a/packages/sdk-angular/docs/classes/FusionAuthRegisterButtonComponent.md
+++ b/packages/sdk-angular/docs/classes/FusionAuthRegisterButtonComponent.md
@@ -25,8 +25,8 @@
 
 #### Parameters
 
-| Name         | Type                                                                                   |
-| :----------- | :------------------------------------------------------------------------------------- |
+| Name | Type |
+| :------ | :------ |
 | `fusionAuth` | [`FusionAuthService`](FusionAuthService.md)\<[`UserInfo`](../interfaces/UserInfo.md)\> |
 
 #### Returns
@@ -35,7 +35,7 @@
 
 #### Defined in
 
-[lib/components/fusionauth-register.button/fusion-auth-register-button.component.ts:12](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/components/fusionauth-register.button/fusion-auth-register-button.component.ts#L12)
+[lib/components/fusionauth-register.button/fusion-auth-register-button.component.ts:15](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/components/fusionauth-register.button/fusion-auth-register-button.component.ts#L15)
 
 ## Properties
 
@@ -45,9 +45,9 @@
 
 #### Defined in
 
-[lib/components/fusionauth-register.button/fusion-auth-register-button.component.ts:12](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/components/fusionauth-register.button/fusion-auth-register-button.component.ts#L12)
+[lib/components/fusionauth-register.button/fusion-auth-register-button.component.ts:15](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/components/fusionauth-register.button/fusion-auth-register-button.component.ts#L15)
 
----
+___
 
 ### state
 
@@ -55,7 +55,7 @@
 
 #### Defined in
 
-[lib/components/fusionauth-register.button/fusion-auth-register-button.component.ts:10](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/components/fusionauth-register.button/fusion-auth-register-button.component.ts#L10)
+[lib/components/fusionauth-register.button/fusion-auth-register-button.component.ts:13](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/components/fusionauth-register.button/fusion-auth-register-button.component.ts#L13)
 
 ## Methods
 
@@ -69,4 +69,4 @@
 
 #### Defined in
 
-[lib/components/fusionauth-register.button/fusion-auth-register-button.component.ts:14](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/components/fusionauth-register.button/fusion-auth-register-button.component.ts#L14)
+[lib/components/fusionauth-register.button/fusion-auth-register-button.component.ts:17](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/components/fusionauth-register.button/fusion-auth-register-button.component.ts#L17)

--- a/packages/sdk-angular/docs/classes/FusionAuthService.md
+++ b/packages/sdk-angular/docs/classes/FusionAuthService.md
@@ -6,9 +6,9 @@ Service class to use with FusionAuth backend endpoints.
 
 ## Type parameters
 
-| Name | Type                                    |
-| :--- | :-------------------------------------- |
-| `T`  | [`UserInfo`](../interfaces/UserInfo.md) |
+| Name | Type |
+| :------ | :------ |
+| `T` | [`UserInfo`](../interfaces/UserInfo.md) |
 
 ## Table of contents
 
@@ -43,16 +43,16 @@ Service class to use with FusionAuth backend endpoints.
 
 #### Type parameters
 
-| Name | Type                                    |
-| :--- | :-------------------------------------- |
-| `T`  | [`UserInfo`](../interfaces/UserInfo.md) |
+| Name | Type |
+| :------ | :------ |
+| `T` | [`UserInfo`](../interfaces/UserInfo.md) |
 
 #### Parameters
 
-| Name         | Type                                                    |
-| :----------- | :------------------------------------------------------ |
-| `config`     | [`FusionAuthConfig`](../interfaces/FusionAuthConfig.md) |
-| `platformId` | `Object`                                                |
+| Name | Type |
+| :------ | :------ |
+| `config` | [`FusionAuthConfig`](../interfaces/FusionAuthConfig.md) |
+| `platformId` | `Object` |
 
 #### Returns
 
@@ -60,7 +60,7 @@ Service class to use with FusionAuth backend endpoints.
 
 #### Defined in
 
-[lib/fusion-auth.service.ts:21](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.ts#L21)
+[lib/fusion-auth.service.ts:21](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.ts#L21)
 
 ## Properties
 
@@ -70,9 +70,9 @@ Service class to use with FusionAuth backend endpoints.
 
 #### Defined in
 
-[lib/fusion-auth.service.ts:18](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.ts#L18)
+[lib/fusion-auth.service.ts:18](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.ts#L18)
 
----
+___
 
 ### core
 
@@ -80,9 +80,9 @@ Service class to use with FusionAuth backend endpoints.
 
 #### Defined in
 
-[lib/fusion-auth.service.ts:17](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.ts#L17)
+[lib/fusion-auth.service.ts:17](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.ts#L17)
 
----
+___
 
 ### isLoggedIn$
 
@@ -92,9 +92,9 @@ An observable representing whether the user is logged in.
 
 #### Defined in
 
-[lib/fusion-auth.service.ts:44](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.ts#L44)
+[lib/fusion-auth.service.ts:44](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.ts#L44)
 
----
+___
 
 ### isLoggedInSubject
 
@@ -102,7 +102,7 @@ An observable representing whether the user is logged in.
 
 #### Defined in
 
-[lib/fusion-auth.service.ts:19](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.ts#L19)
+[lib/fusion-auth.service.ts:19](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.ts#L19)
 
 ## Methods
 
@@ -115,8 +115,8 @@ Fetches userInfo from the 'me' endpoint.
 #### Type parameters
 
 | Name |
-| :--- |
-| `T`  |
+| :------ |
+| `T` |
 
 #### Returns
 
@@ -128,9 +128,9 @@ Fetches userInfo from the 'me' endpoint.
 
 #### Defined in
 
-[lib/fusion-auth.service.ts:102](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.ts#L102)
+[lib/fusion-auth.service.ts:102](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.ts#L102)
 
----
+___
 
 ### getUserInfoObservable
 
@@ -140,11 +140,11 @@ Returns an observable request that fetches userInfo, and catches error.
 
 #### Parameters
 
-| Name                 | Type         |
-| :------------------- | :----------- |
-| `callbacks?`         | `Object`     |
+| Name | Type |
+| :------ | :------ |
+| `callbacks?` | `Object` |
 | `callbacks.onBegin?` | () => `void` |
-| `callbacks.onDone?`  | () => `void` |
+| `callbacks.onDone?` | () => `void` |
 
 #### Returns
 
@@ -152,9 +152,9 @@ Returns an observable request that fetches userInfo, and catches error.
 
 #### Defined in
 
-[lib/fusion-auth.service.ts:74](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.ts#L74)
+[lib/fusion-auth.service.ts:74](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.ts#L74)
 
----
+___
 
 ### initAutoRefresh
 
@@ -169,9 +169,9 @@ This is handled automatically if the SDK is configured with `shouldAutoRefresh`.
 
 #### Defined in
 
-[lib/fusion-auth.service.ts:63](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.ts#L63)
+[lib/fusion-auth.service.ts:63](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.ts#L63)
 
----
+___
 
 ### isLoggedIn
 
@@ -185,9 +185,9 @@ A function that returns whether the user is logged in. This returned value is no
 
 #### Defined in
 
-[lib/fusion-auth.service.ts:47](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.ts#L47)
+[lib/fusion-auth.service.ts:47](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.ts#L47)
 
----
+___
 
 ### logout
 
@@ -201,9 +201,9 @@ Initiates logout flow.
 
 #### Defined in
 
-[lib/fusion-auth.service.ts:125](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.ts#L125)
+[lib/fusion-auth.service.ts:125](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.ts#L125)
 
----
+___
 
 ### manageAccount
 
@@ -218,9 +218,9 @@ Self service account management is only available in FusionAuth paid plans.
 
 #### Defined in
 
-[lib/fusion-auth.service.ts:133](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.ts#L133)
+[lib/fusion-auth.service.ts:133](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.ts#L133)
 
----
+___
 
 ### refreshToken
 
@@ -235,9 +235,9 @@ Automatic token refreshing can be enabled if the SDK is configured with `shouldA
 
 #### Defined in
 
-[lib/fusion-auth.service.ts:55](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.ts#L55)
+[lib/fusion-auth.service.ts:55](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.ts#L55)
 
----
+___
 
 ### startLogin
 
@@ -247,8 +247,8 @@ Initiates login flow.
 
 #### Parameters
 
-| Name     | Type     | Description                                                |
-| :------- | :------- | :--------------------------------------------------------- |
+| Name | Type | Description |
+| :------ | :------ | :------ |
 | `state?` | `string` | Optional value to be echoed back to the SDK upon redirect. |
 
 #### Returns
@@ -257,9 +257,9 @@ Initiates login flow.
 
 #### Defined in
 
-[lib/fusion-auth.service.ts:110](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.ts#L110)
+[lib/fusion-auth.service.ts:110](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.ts#L110)
 
----
+___
 
 ### startRegistration
 
@@ -269,8 +269,8 @@ Initiates register flow.
 
 #### Parameters
 
-| Name     | Type     | Description                                                |
-| :------- | :------- | :--------------------------------------------------------- |
+| Name | Type | Description |
+| :------ | :------ | :------ |
 | `state?` | `string` | Optional value to be echoed back to the SDK upon redirect. |
 
 #### Returns
@@ -279,4 +279,4 @@ Initiates register flow.
 
 #### Defined in
 
-[lib/fusion-auth.service.ts:118](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.ts#L118)
+[lib/fusion-auth.service.ts:118](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.ts#L118)

--- a/packages/sdk-angular/docs/interfaces/FusionAuthConfig.md
+++ b/packages/sdk-angular/docs/interfaces/FusionAuthConfig.md
@@ -8,6 +8,7 @@ Config for FusionAuth Angular SDK
 
 ### Properties
 
+- [authParams](FusionAuthConfig.md#authparams)
 - [autoRefreshSecondsBeforeExpiry](FusionAuthConfig.md#autorefreshsecondsbeforeexpiry)
 - [clientId](FusionAuthConfig.md#clientid)
 - [loginPath](FusionAuthConfig.md#loginpath)
@@ -25,6 +26,18 @@ Config for FusionAuth Angular SDK
 
 ## Properties
 
+### authParams
+
+• `Optional` **authParams**: \{ `[key: string]`: `any`;  }[]
+
+Params to be appended to the authorize request.
+
+#### Defined in
+
+[lib/types.ts:78](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L78)
+
+___
+
 ### autoRefreshSecondsBeforeExpiry
 
 • `Optional` **autoRefreshSecondsBeforeExpiry**: `number`
@@ -33,9 +46,9 @@ The number of seconds before the access token expiry when the auto refresh funct
 
 #### Defined in
 
-[lib/types.ts:38](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L38)
+[lib/types.ts:38](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L38)
 
----
+___
 
 ### clientId
 
@@ -45,9 +58,9 @@ The client id of the application.
 
 #### Defined in
 
-[lib/types.ts:13](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L13)
+[lib/types.ts:13](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L13)
 
----
+___
 
 ### loginPath
 
@@ -57,9 +70,9 @@ The path to the login endpoint.
 
 #### Defined in
 
-[lib/types.ts:53](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L53)
+[lib/types.ts:53](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L53)
 
----
+___
 
 ### logoutPath
 
@@ -69,9 +82,9 @@ The path to the logout endpoint.
 
 #### Defined in
 
-[lib/types.ts:63](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L63)
+[lib/types.ts:63](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L63)
 
----
+___
 
 ### mePath
 
@@ -81,9 +94,9 @@ The path to the me endpoint.
 
 #### Defined in
 
-[lib/types.ts:73](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L73)
+[lib/types.ts:73](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L73)
 
----
+___
 
 ### onAutoRefreshFailure
 
@@ -97,7 +110,7 @@ Callback to be invoked if a request to refresh the access token fails during aut
 
 ##### Parameters
 
-| Name    | Type    |
+| Name | Type |
 | :------ | :------ |
 | `error` | `Error` |
 
@@ -107,9 +120,9 @@ Callback to be invoked if a request to refresh the access token fails during aut
 
 #### Defined in
 
-[lib/types.ts:48](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L48)
+[lib/types.ts:48](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L48)
 
----
+___
 
 ### onRedirect
 
@@ -123,8 +136,8 @@ Callback function to be invoked with the `state` value upon redirect from login 
 
 ##### Parameters
 
-| Name     | Type     |
-| :------- | :------- |
+| Name | Type |
+| :------ | :------ |
 | `state?` | `string` |
 
 ##### Returns
@@ -133,9 +146,9 @@ Callback function to be invoked with the `state` value upon redirect from login 
 
 #### Defined in
 
-[lib/types.ts:43](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L43)
+[lib/types.ts:43](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L43)
 
----
+___
 
 ### postLogoutRedirectUri
 
@@ -145,9 +158,9 @@ The redirect URI for post-logout. Defaults the provided `redirectUri`.
 
 #### Defined in
 
-[lib/types.ts:23](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L23)
+[lib/types.ts:23](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L23)
 
----
+___
 
 ### redirectUri
 
@@ -157,9 +170,9 @@ The redirect URI of the application.
 
 #### Defined in
 
-[lib/types.ts:18](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L18)
+[lib/types.ts:18](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L18)
 
----
+___
 
 ### registerPath
 
@@ -169,9 +182,9 @@ The path to the register endpoint.
 
 #### Defined in
 
-[lib/types.ts:58](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L58)
+[lib/types.ts:58](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L58)
 
----
+___
 
 ### scope
 
@@ -181,9 +194,9 @@ The OAuth2 scope parameter passed to the `/oauth2/authorize` endpoint. If not sp
 
 #### Defined in
 
-[lib/types.ts:28](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L28)
+[lib/types.ts:28](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L28)
 
----
+___
 
 ### serverUrl
 
@@ -193,9 +206,9 @@ The URL of the server that performs the token exchange.
 
 #### Defined in
 
-[lib/types.ts:8](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L8)
+[lib/types.ts:8](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L8)
 
----
+___
 
 ### shouldAutoRefresh
 
@@ -205,9 +218,9 @@ Enables automatic token refreshing. Defaults to false.
 
 #### Defined in
 
-[lib/types.ts:33](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L33)
+[lib/types.ts:33](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L33)
 
----
+___
 
 ### tokenRefreshPath
 
@@ -217,4 +230,4 @@ The path to the token refresh endpoint.
 
 #### Defined in
 
-[lib/types.ts:68](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L68)
+[lib/types.ts:68](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L68)

--- a/packages/sdk-angular/docs/interfaces/UserInfo.md
+++ b/packages/sdk-angular/docs/interfaces/UserInfo.md
@@ -9,14 +9,14 @@
 - [applicationId](UserInfo.md#applicationid)
 - [birthdate](UserInfo.md#birthdate)
 - [email](UserInfo.md#email)
-- [email_verified](UserInfo.md#email_verified)
-- [family_name](UserInfo.md#family_name)
-- [given_name](UserInfo.md#given_name)
-- [middle_name](UserInfo.md#middle_name)
+- [email\_verified](UserInfo.md#email_verified)
+- [family\_name](UserInfo.md#family_name)
+- [given\_name](UserInfo.md#given_name)
+- [middle\_name](UserInfo.md#middle_name)
 - [name](UserInfo.md#name)
-- [phone_number](UserInfo.md#phone_number)
+- [phone\_number](UserInfo.md#phone_number)
 - [picture](UserInfo.md#picture)
-- [preferred_username](UserInfo.md#preferred_username)
+- [preferred\_username](UserInfo.md#preferred_username)
 - [roles](UserInfo.md#roles)
 - [sid](UserInfo.md#sid)
 - [sub](UserInfo.md#sub)
@@ -30,9 +30,9 @@
 
 #### Defined in
 
-[lib/types.ts:77](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L77)
+[lib/types.ts:82](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L82)
 
----
+___
 
 ### birthdate
 
@@ -40,9 +40,9 @@
 
 #### Defined in
 
-[lib/types.ts:78](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L78)
+[lib/types.ts:83](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L83)
 
----
+___
 
 ### email
 
@@ -50,49 +50,49 @@
 
 #### Defined in
 
-[lib/types.ts:79](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L79)
+[lib/types.ts:84](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L84)
 
----
+___
 
-### email_verified
+### email\_verified
 
-• `Optional` **email_verified**: `boolean`
-
-#### Defined in
-
-[lib/types.ts:80](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L80)
-
----
-
-### family_name
-
-• `Optional` **family_name**: `string`
+• `Optional` **email\_verified**: `boolean`
 
 #### Defined in
 
-[lib/types.ts:81](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L81)
+[lib/types.ts:85](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L85)
 
----
+___
 
-### given_name
+### family\_name
 
-• `Optional` **given_name**: `string`
-
-#### Defined in
-
-[lib/types.ts:82](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L82)
-
----
-
-### middle_name
-
-• `Optional` **middle_name**: `string`
+• `Optional` **family\_name**: `string`
 
 #### Defined in
 
-[lib/types.ts:83](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L83)
+[lib/types.ts:86](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L86)
 
----
+___
+
+### given\_name
+
+• `Optional` **given\_name**: `string`
+
+#### Defined in
+
+[lib/types.ts:87](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L87)
+
+___
+
+### middle\_name
+
+• `Optional` **middle\_name**: `string`
+
+#### Defined in
+
+[lib/types.ts:88](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L88)
+
+___
 
 ### name
 
@@ -100,19 +100,19 @@
 
 #### Defined in
 
-[lib/types.ts:84](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L84)
+[lib/types.ts:89](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L89)
 
----
+___
 
-### phone_number
+### phone\_number
 
-• `Optional` **phone_number**: `string`
+• `Optional` **phone\_number**: `string`
 
 #### Defined in
 
-[lib/types.ts:85](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L85)
+[lib/types.ts:90](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L90)
 
----
+___
 
 ### picture
 
@@ -120,19 +120,19 @@
 
 #### Defined in
 
-[lib/types.ts:86](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L86)
+[lib/types.ts:91](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L91)
 
----
+___
 
-### preferred_username
+### preferred\_username
 
-• `Optional` **preferred_username**: `string`
+• `Optional` **preferred\_username**: `string`
 
 #### Defined in
 
-[lib/types.ts:87](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L87)
+[lib/types.ts:92](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L92)
 
----
+___
 
 ### roles
 
@@ -140,9 +140,9 @@
 
 #### Defined in
 
-[lib/types.ts:88](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L88)
+[lib/types.ts:93](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L93)
 
----
+___
 
 ### sid
 
@@ -150,9 +150,9 @@
 
 #### Defined in
 
-[lib/types.ts:89](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L89)
+[lib/types.ts:94](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L94)
 
----
+___
 
 ### sub
 
@@ -160,9 +160,9 @@
 
 #### Defined in
 
-[lib/types.ts:90](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L90)
+[lib/types.ts:95](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L95)
 
----
+___
 
 ### tid
 
@@ -170,4 +170,4 @@
 
 #### Defined in
 
-[lib/types.ts:91](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/80c01c9ccb450a2187bc0d2cc65fa8c9c38cfabe/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L91)
+[lib/types.ts:96](https://github.com/getabetterpic/fusionauth-javascript-sdk/blob/6caa06a6b24710315cf53a4507c3fcff90aee5cd/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts#L96)

--- a/packages/sdk-angular/projects/fusionauth-angular-sdk/package.json
+++ b/packages/sdk-angular/projects/fusionauth-angular-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fusionauth/angular-sdk",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "peerDependencies": {
     "@angular/common": ">=17.2.0",
     "@angular/core": ">=17.2.0"

--- a/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts
+++ b/packages/sdk-angular/projects/fusionauth-angular-sdk/src/lib/types.ts
@@ -71,6 +71,11 @@ export interface FusionAuthConfig {
    * The path to the me endpoint.
    */
   mePath?: string;
+
+  /**
+   * Params to be appended to the authorize request.
+   */
+  authParams?: { [key: string]: any }[];
 }
 
 export interface UserInfo {


### PR DESCRIPTION
## What is this PR and why do we need it?

The SDKCore lib implements an `authParams` config option to pass params to the authorization requests. However, that did not make it into the latest Angular version.

- Add the `authParams` option to the Angular FusionAuthConfig interface so we can pass it into the `forRoot()` import. My specific use case is needing to pass the `tenantId` param in so the universal application knows which tenant to attach to.
- Bump Angular SDK version to 1.4.0

#### Pre-Merge Checklist (if applicable)

- [ ] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.
