### PR TITLE
fix: playwright end to end test failures

### DIFF
--- a/e2e/pages/common.page.ts
+++ b/e2e/pages/common.page.ts
@@ -2,7 +2,7 @@ import { Locator, Page, expect } from '@playwright/test';
 
 const Locators = {
   logInBtn: 'role=button[name="Login"]',
-  emailInput: 'role=textbox[name="Email"]',
+  emailInput: 'role=textbox[name="Login"]',
   passwordInput: 'role=textbox[name="Password"]',
   submitBtn: 'role=button[name="Submit"]',
   createAccountBtn: 'role=button[name="Create a new account."]',

--- a/e2e/pages/common.page.ts
+++ b/e2e/pages/common.page.ts
@@ -2,7 +2,7 @@ import { Locator, Page, expect } from '@playwright/test';
 
 const Locators = {
   logInBtn: 'role=button[name="Login"]',
-  emailInput: 'role=textbox[name="Login"]',
+  loginInput: 'role=textbox[name="Login"]',
   passwordInput: 'role=textbox[name="Password"]',
   submitBtn: 'role=button[name="Submit"]',
   createAccountBtn: 'role=button[name="Create a new account."]',
@@ -29,13 +29,13 @@ export class quickstartPage {
 
   async navToLogIn() {
     await this.locators.logInBtn.nth(0).click();
-    await expect(this.locators.emailInput).toBeVisible();
+    await expect(this.locators.loginInput).toBeVisible();
   }
 
   async authenticate() {
-    await this.locators.emailInput.click();
-    await this.locators.emailInput.clear();
-    await this.locators.emailInput.fill('richard@example.com');
+    await this.locators.loginInput.click();
+    await this.locators.loginInput.clear();
+    await this.locators.loginInput.fill('richard@example.com');
     await this.locators.passwordInput.click();
     await this.locators.passwordInput.clear();
     await this.locators.passwordInput.fill('password');

--- a/e2e/tests/cookies.test.ts
+++ b/e2e/tests/cookies.test.ts
@@ -10,6 +10,9 @@ test.describe('Login Endpoint Tests', () => {
     browserContext = await browser.newContext();
     page = await browserContext.newPage();
     quickstart = new quickstartPage(page);
+  });
+
+  test.beforeEach(async ({ browser }) => {
     await page.goto('/');
     await quickstart.navToLogIn();
   });
@@ -49,6 +52,7 @@ test.describe('Login Endpoint Tests', () => {
     checkCookieExistsAndHttpOnly(cookies, 'app.at_exp', false);
     checkCookieExistsAndHttpOnly(cookies, 'app.idt', false);
     checkCookieExistsAndHttpOnly(cookies, 'app.rt', true);
+    await quickstart.logOut();
   });
 
   test('Post Logout Cookies', async () => {

--- a/e2e/tests/cookies.test.ts
+++ b/e2e/tests/cookies.test.ts
@@ -12,7 +12,7 @@ test.describe('Login Endpoint Tests', () => {
     quickstart = new quickstartPage(page);
   });
 
-  test.beforeEach(async ({ browser }) => {
+  test.beforeEach(async () => {
     await page.goto('/');
     await quickstart.navToLogIn();
   });

--- a/e2e/tests/cookies.test.ts
+++ b/e2e/tests/cookies.test.ts
@@ -2,6 +2,8 @@ import { Page, test, BrowserContext, expect, Cookie } from '@playwright/test';
 import { quickstartPage } from '../pages/common.page';
 
 test.describe('Login Endpoint Tests', () => {
+  test.describe.configure({ mode: 'serial' });
+
   let page: Page;
   let quickstart: quickstartPage;
   let browserContext: BrowserContext;

--- a/e2e/tests/endpoints.test.ts
+++ b/e2e/tests/endpoints.test.ts
@@ -14,6 +14,10 @@ test.describe('Endpoint Tests', () => {
     quickstart = new quickstartPage(page);
   });
 
+  test.afterAll(async () => {
+    await page?.close();
+    await browserContext?.close();
+  });
   test.beforeEach(async () => {
     await page.goto('/');
     await quickstart.navToLogIn();

--- a/e2e/tests/endpoints.test.ts
+++ b/e2e/tests/endpoints.test.ts
@@ -2,6 +2,8 @@ import { Page, test, BrowserContext, expect } from '@playwright/test';
 import { quickstartPage } from '../pages/common.page';
 
 test.describe('Endpoint Tests', () => {
+  test.describe.configure({ mode: 'serial' });
+
   let page: Page;
   let quickstart: quickstartPage;
   let browserContext: BrowserContext;

--- a/e2e/tests/endpoints.test.ts
+++ b/e2e/tests/endpoints.test.ts
@@ -12,7 +12,7 @@ test.describe('Endpoint Tests', () => {
     quickstart = new quickstartPage(page);
   });
 
-  test.beforeEach(async ({ browser }) => {
+  test.beforeEach(async () => {
     await page.goto('/');
     await quickstart.navToLogIn();
     await quickstart.authenticate();

--- a/e2e/tests/endpoints.test.ts
+++ b/e2e/tests/endpoints.test.ts
@@ -10,6 +10,9 @@ test.describe('Endpoint Tests', () => {
     browserContext = await browser.newContext();
     page = await browserContext.newPage();
     quickstart = new quickstartPage(page);
+  });
+
+  test.beforeEach(async ({ browser }) => {
     await page.goto('/');
     await quickstart.navToLogIn();
     await quickstart.authenticate();
@@ -37,6 +40,8 @@ test.describe('Endpoint Tests', () => {
 
     expect(response.headers()['content-type']).toContain('application/json');
     expect(response.ok()).toBeTruthy();
+
+    await quickstart.logOut();
   });
 
   test('GET /app/logout', async () => {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
   /* Opt out of parallel tests on CI. */
-  workers: 9,
+  workers: 1,
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
+  /* Run tests in a single worker */
   workers: 1,
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {


### PR DESCRIPTION
## What is this PR and why do we need it?

E2E test suites share a single `browserContext`/`page` across tests via `beforeAll`, while `fullyParallel: true` in the Playwright config allows concurrent test execution — causing races and flaky failures on shared state.

**Changes:**
- `e2e/tests/endpoints.test.ts` / `e2e/tests/cookies.test.ts`: Add `test.describe.configure({ mode: 'serial' })` to enforce sequential execution within each describe block, eliminating races on the shared `page`/`browserContext`
- `e2e/pages/common.page.ts`: Update login input locator to match current accessible name (`"Login"`); rename field from `emailInput` → `loginInput` for accuracy

```ts
test.describe('Endpoint Tests', () => {
  test.describe.configure({ mode: 'serial' }); // ← ensures shared page/context is safe
  // ...
});
```

#### Pre-Merge Checklist (if applicable)

- [x] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.