### PR TITLE
Use OIDC to publish the React package to npmjs

### DIFF
--- a/.github/workflows/lint-and-format.yml
+++ b/.github/workflows/lint-and-format.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [22.x, 24.x, 26.x]
+        node-version: [22.x, 24.x]
     steps:
       - uses: actions/checkout@v6
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/lint-and-format.yml
+++ b/.github/workflows/lint-and-format.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [22.x, 24.x, 26.x]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/publish-sdk-angular.yml
+++ b/.github/workflows/publish-sdk-angular.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [22.x, 24.x, 26.x]
+        node-version: [22.x, 24.x]
     steps:
       - uses: actions/checkout@v6
       - name: Use Node.js ${{ matrix.node-version }}
@@ -35,7 +35,7 @@ jobs:
       - name: setup node for publishing
         uses: actions/setup-node@v4
         with:
-          node-version: '26'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org' # This generates the necessary .npmrc
 
       - name: Angular SDK - Install packages

--- a/.github/workflows/publish-sdk-angular.yml
+++ b/.github/workflows/publish-sdk-angular.yml
@@ -2,14 +2,18 @@ name: Publish @fusionauth/angular-sdk
 
 on: workflow_dispatch
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [22.x, 24.x, 26.x]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
@@ -27,17 +31,23 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Use Node.js 20
+      - uses: actions/checkout@v6
+      - name: setup node for publishing
         uses: actions/setup-node@v4
         with:
-          node-version: 20
-          registry-url: https://registry.npmjs.org/
-      - run: yarn install --frozen-lockfile
+          node-version: '26'
+          registry-url: 'https://registry.npmjs.org' # This generates the necessary .npmrc
+
+      - name: Angular SDK - Install packages
+        run: yarn install --frozen-lockfile
+
       - name: Angular SDK - Build
         run: yarn build:sdk-angular
+
       - name: Angular SDK - Publish
         working-directory: ./packages/sdk-angular/dist/fusionauth-angular-sdk
-        run: npm publish
+        run: |
+          npm install -g npm@latest
+          npm publish --provenance --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_ANGULAR_SDK }}
+          NODE_AUTH_TOKEN: 'sigstore' # npm uses OIDC when this is any non-empty string

--- a/.github/workflows/publish-sdk-react.yml
+++ b/.github/workflows/publish-sdk-react.yml
@@ -38,7 +38,7 @@ jobs:
       - name: React SDK - Publish
         working-directory: ./packages/sdk-react/dist
         run: |
-          npm publish --provenance --access public
+          npm publish
         env:
           NODE_AUTH_TOKEN: 'sigstore' # npm uses OIDC when this is any non-empty string
 

--- a/.github/workflows/publish-sdk-react.yml
+++ b/.github/workflows/publish-sdk-react.yml
@@ -43,24 +43,24 @@ jobs:
       - name: React SDK - Build
         run: yarn build:sdk-react
 
-      - name: set aws credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::752443094709:role/gha-fusionauth-javascript-sdk
-          role-session-name: aws-auth-action
-          aws-region: us-west-2
+      # - name: set aws credentials
+      #   uses: aws-actions/configure-aws-credentials@v4
+      #   with:
+      #     role-to-assume: arn:aws:iam::752443094709:role/gha-fusionauth-javascript-sdk
+      #     role-session-name: aws-auth-action
+      #     aws-region: us-west-2
 
-      - name: get secret
-        run: |
-          while IFS=$'\t' read -r key value; do
-            echo "::add-mask::${value}"
-            echo "${key}=${value}" >> $GITHUB_ENV
-          done < <(aws secretsmanager get-secret-value \
-            --region us-west-2 \
-            --secret-id platform/npmjs \
-            --query SecretString \
-            --output text | \
-            jq -r 'to_entries[] | [.key, .value] | @tsv')
+      # - name: get secret
+      #   run: |
+      #     while IFS=$'\t' read -r key value; do
+      #       echo "::add-mask::${value}"
+      #       echo "${key}=${value}" >> $GITHUB_ENV
+      #     done < <(aws secretsmanager get-secret-value \
+      #       --region us-west-2 \
+      #       --secret-id platform/npmjs \
+      #       --query SecretString \
+      #       --output text | \
+      #       jq -r 'to_entries[] | [.key, .value] | @tsv')
 
       - name: React SDK - Publish
         run: |

--- a/.github/workflows/publish-sdk-react.yml
+++ b/.github/workflows/publish-sdk-react.yml
@@ -44,6 +44,7 @@ jobs:
         run: yarn build:sdk-react
 
       - name: React SDK - Publish
+        working-directory: packages/sdk-react
         run: |
           npm install -g npm@latest
           npm publish --provenance --access public

--- a/.github/workflows/publish-sdk-react.yml
+++ b/.github/workflows/publish-sdk-react.yml
@@ -2,6 +2,10 @@ name: Publish @fusionauth/react-sdk
 
 on: workflow_dispatch
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -27,18 +31,40 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 20
+      - name: setup node for publishing
         uses: actions/setup-node@v4
         with:
-          node-version: 20
-          registry-url: https://registry.npmjs.org/
-      - run: yarn install --frozen-lockfile
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org' # This generates the necessary .npmrc
+
+      - name: React SDK - Install packages
+        run: yarn install --frozen-lockfile
+
       - name: React SDK - Build
         run: yarn build:sdk-react
-      - name: React SDK - Publish
-        working-directory: ./packages/sdk-react/dist
-        run: |
-          npm publish
-        env:
-          NODE_AUTH_TOKEN: 'sigstore' # npm uses OIDC when this is any non-empty string
 
+      - name: set aws credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::752443094709:role/gha-fusionauth-typescript-client
+          role-session-name: aws-auth-action
+          aws-region: us-west-2
+
+      - name: get secret
+        run: |
+          while IFS=$'\t' read -r key value; do
+            echo "::add-mask::${value}"
+            echo "${key}=${value}" >> $GITHUB_ENV
+          done < <(aws secretsmanager get-secret-value \
+            --region us-west-2 \
+            --secret-id platform/npmjs \
+            --query SecretString \
+            --output text | \
+            jq -r 'to_entries[] | [.key, .value] | @tsv')
+
+      - name: React SDK - Publish
+        run: |
+          npm install -g npm@latest
+          npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: 'sigstore' # npm uses OIDC when this is any non-empty strin

--- a/.github/workflows/publish-sdk-react.yml
+++ b/.github/workflows/publish-sdk-react.yml
@@ -37,6 +37,8 @@ jobs:
         run: yarn build:sdk-react
       - name: React SDK - Publish
         working-directory: ./packages/sdk-react/dist
-        run: npm publish
+        run: |
+          npm publish --provenance --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_REACT_SDK }}
+          NODE_AUTH_TOKEN: 'sigstore' # npm uses OIDC when this is any non-empty string
+

--- a/.github/workflows/publish-sdk-react.yml
+++ b/.github/workflows/publish-sdk-react.yml
@@ -46,7 +46,7 @@ jobs:
       - name: set aws credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::752443094709:role/gha-fusionauth-typescript-client
+          role-to-assume: arn:aws:iam::752443094709:role/gha-fusionauth-javascript-client
           role-session-name: aws-auth-action
           aws-region: us-west-2
 

--- a/.github/workflows/publish-sdk-react.yml
+++ b/.github/workflows/publish-sdk-react.yml
@@ -48,3 +48,5 @@ jobs:
         run: |
           npm install -g npm@latest
           npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: 'sigstore' # npm uses OIDC when this is any non-empty string

--- a/.github/workflows/publish-sdk-react.yml
+++ b/.github/workflows/publish-sdk-react.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [22.x, 24.x, 26.x]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
@@ -30,11 +30,11 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: setup node for publishing
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '26'
           registry-url: 'https://registry.npmjs.org' # This generates the necessary .npmrc
 
       - name: React SDK - Install packages

--- a/.github/workflows/publish-sdk-react.yml
+++ b/.github/workflows/publish-sdk-react.yml
@@ -46,7 +46,7 @@ jobs:
       - name: set aws credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::752443094709:role/gha-fusionauth-javascript-client
+          role-to-assume: arn:aws:iam::752443094709:role/gha-fusionauth-javascript-sdk
           role-session-name: aws-auth-action
           aws-region: us-west-2
 

--- a/.github/workflows/publish-sdk-react.yml
+++ b/.github/workflows/publish-sdk-react.yml
@@ -43,25 +43,6 @@ jobs:
       - name: React SDK - Build
         run: yarn build:sdk-react
 
-      # - name: set aws credentials
-      #   uses: aws-actions/configure-aws-credentials@v4
-      #   with:
-      #     role-to-assume: arn:aws:iam::752443094709:role/gha-fusionauth-javascript-sdk
-      #     role-session-name: aws-auth-action
-      #     aws-region: us-west-2
-
-      # - name: get secret
-      #   run: |
-      #     while IFS=$'\t' read -r key value; do
-      #       echo "::add-mask::${value}"
-      #       echo "${key}=${value}" >> $GITHUB_ENV
-      #     done < <(aws secretsmanager get-secret-value \
-      #       --region us-west-2 \
-      #       --secret-id platform/npmjs \
-      #       --query SecretString \
-      #       --output text | \
-      #       jq -r 'to_entries[] | [.key, .value] | @tsv')
-
       - name: React SDK - Publish
         run: |
           npm install -g npm@latest

--- a/.github/workflows/publish-sdk-react.yml
+++ b/.github/workflows/publish-sdk-react.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [22.x, 24.x, 26.x]
+        node-version: [22.x, 24.x]
     steps:
       - uses: actions/checkout@v6
       - name: Use Node.js ${{ matrix.node-version }}
@@ -34,7 +34,7 @@ jobs:
       - name: setup node for publishing
         uses: actions/setup-node@v4
         with:
-          node-version: '26'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org' # This generates the necessary .npmrc
 
       - name: React SDK - Install packages

--- a/.github/workflows/publish-sdk-react.yml
+++ b/.github/workflows/publish-sdk-react.yml
@@ -48,5 +48,3 @@ jobs:
         run: |
           npm install -g npm@latest
           npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: 'sigstore' # npm uses OIDC when this is any non-empty strin

--- a/.github/workflows/publish-sdk-vue.yml
+++ b/.github/workflows/publish-sdk-vue.yml
@@ -2,14 +2,18 @@ name: Publish @fusionauth/vue-sdk
 
 on: workflow_dispatch
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [22.x, 24.x, 26.x]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
@@ -26,17 +30,23 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Use Node.js 20
+      - uses: actions/checkout@v6
+      - name: setup node for publishing
         uses: actions/setup-node@v4
         with:
-          node-version: 20
-          registry-url: https://registry.npmjs.org/
-      - run: yarn install --frozen-lockfile
+          node-version: '26'
+          registry-url: 'https://registry.npmjs.org' # This generates the necessary .npmrc
+
+      - name: Vue SDK - Install packages
+        run: yarn install --frozen-lockfile
+
       - name: Vue SDK - Build
         run: yarn build:sdk-vue
+
       - name: Vue SDK - Publish
         working-directory: ./packages/sdk-vue/dist
-        run: npm publish
+        run: |
+          npm install -g npm@latest
+          npm publish --provenance --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_VUE_SDK }}
+          NODE_AUTH_TOKEN: 'sigstore' # npm uses OIDC when this is any non-empty string

--- a/.github/workflows/publish-sdk-vue.yml
+++ b/.github/workflows/publish-sdk-vue.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [22.x, 24.x, 26.x]
+        node-version: [22.x, 24.x]
     steps:
       - uses: actions/checkout@v6
       - name: Use Node.js ${{ matrix.node-version }}
@@ -34,7 +34,7 @@ jobs:
       - name: setup node for publishing
         uses: actions/setup-node@v4
         with:
-          node-version: '26'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org' # This generates the necessary .npmrc
 
       - name: Vue SDK - Install packages

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [22.x, 24.x, 26.x]
+        node-version: [22.x, 24.x]
     steps:
       - uses: actions/checkout@v6
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [22.x, 24.x, 26.x]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:

--- a/packages/sdk-react/package.json
+++ b/packages/sdk-react/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@fusionauth/react-sdk",
   "version": "2.5.2",
-  "private": false,
   "description": "FusionAuth solves the problem of building essential security without adding risk or distracting from your primary application",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Use OIDC to publish the React package to npmjs vs a GitHub token in Secrets.  NPM doesn't want us using tokens anymore.