### PR TITLE
build: GitHub workflows to publish the React and Angular SDKs to npmjs are failing

### DIFF
--- a/packages/sdk-angular/package.json
+++ b/packages/sdk-angular/package.json
@@ -9,15 +9,6 @@
     "test:watch": "ng test",
     "docs": "typedoc --plugin typedoc-plugin-markdown"
   },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/FusionAuth/fusionauth-javascript-sdk"
-  },
-  "author": "FusionAuth",
-  "license": "Apache",
-  "bugs": {
-    "url": "https://github.com/FusionAuth/fusionauth-javascript-sdk/issues"
-  },
   "private": false,
   "dependencies": {
     "@angular/animations": "^22.0.0",

--- a/packages/sdk-angular/package.json
+++ b/packages/sdk-angular/package.json
@@ -9,6 +9,15 @@
     "test:watch": "ng test",
     "docs": "typedoc --plugin typedoc-plugin-markdown"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/FusionAuth/fusionauth-javascript-sdk"
+  },
+  "author": "FusionAuth",
+  "license": "Apache",
+  "bugs": {
+    "url": "https://github.com/FusionAuth/fusionauth-javascript-sdk/issues"
+  },
   "private": false,
   "dependencies": {
     "@angular/animations": "^22.0.0",

--- a/packages/sdk-angular/projects/fusionauth-angular-sdk/package.json
+++ b/packages/sdk-angular/projects/fusionauth-angular-sdk/package.json
@@ -8,5 +8,14 @@
   "dependencies": {
     "tslib": "^2.3.0"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/FusionAuth/fusionauth-javascript-sdk"
+  },
+  "author": "FusionAuth",
+  "license": "Apache",
+  "bugs": {
+    "url": "https://github.com/FusionAuth/fusionauth-javascript-sdk/issues"
+  }
 }

--- a/packages/sdk-react/tsconfig.json
+++ b/packages/sdk-react/tsconfig.json
@@ -13,7 +13,7 @@
     "jsx": "react-jsx",
     "sourceMap": true
   },
-  "include": ["src", "vite.config.ts"],
+  "include": ["src"],
   "typedocOptions": {
     "plugin": ["typedoc-plugin-markdown"],
     "entryPoints": [

--- a/packages/sdk-react/vite.config.ts
+++ b/packages/sdk-react/vite.config.ts
@@ -1,4 +1,4 @@
-// <reference types="vitest" />
+/// <reference types="vitest" />
 import { resolve } from 'node:path';
 import { defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';


### PR DESCRIPTION
Description:
The GitHub workflows to publish the React and Angular SDKs to npmjs are failing.

- The Angular SDK needed the repository.url from the package.json as the publishing is now issuing a signed provenance statement with source and build information.
- The React SDK packaging failed due to a build error introduced in the [Angular 22.x.x upgrade](https://github.com/FusionAuth/fusionauth-javascript-sdk/pull/195)

Test:
The React and Angular SDKs have now been published to npmjs.